### PR TITLE
replace URL of definition file to local file before functional test

### DIFF
--- a/.github/workflows/func_test.yaml
+++ b/.github/workflows/func_test.yaml
@@ -32,7 +32,9 @@ jobs:
           sudo apt-get install -y ttf-mscorefonts-installer
 
       - name: Functional tests
-        run: go test -v ./test/...
+        run: |
+          find ./examples/ -name *.yaml | xargs -I_ yq -i '.Diagram.DefinitionFiles[0].Type="LocalFile" | del(.Diagram.DefinitionFiles[0].Url) | .Diagram.DefinitionFiles[0].LocalFile="../definitions/definition-for-aws-icons-light.yaml"' _
+          go test -v ./test/...
 
       - if: failure()
         run: echo "Check artifacts https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID#artifacts"


### PR DESCRIPTION
*Issue #, if available:*
Although the sample file retrieves the definition file from the URL, for testing purposes it is best to test with a local definition file.

*Description of changes:*
Before running the test, refer to the local definition file using the yq command.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
