### PR TITLE
Define AWS::Diagram::Canvas with Group type

### DIFF
--- a/definitions/definition-for-aws-icons-light.yaml
+++ b/definitions/definition-for-aws-icons-light.yaml
@@ -23,6 +23,15 @@ Definitions:
 
   # Groups
 
+  "AWS::Diagram::Canvas":
+    Type: Group
+    Icon:
+      Source: ArchitectureIconsPptxMedia
+      Path: "image928.png"
+    Label:
+      Title: "Canvas"
+      Color: "rgba(0, 0, 0, 255)"
+
   AWS::Diagram::Cloud:
     Type: Group
     Icon:
@@ -4604,15 +4613,6 @@ Definitions:
       Path: "image1337.png"
     Label:
       Title: "AWS Client VPN"
-      Color: "rgba(0, 0, 0, 255)"
-
-  "Canvas":
-    Type: Preset
-    Icon:
-      Source: ArchitectureIconsPptxMedia
-      Path: "image928.png"
-    Label:
-      Title: "Canvas"
       Color: "rgba(0, 0, 0, 255)"
 
   "Folder":


### PR DESCRIPTION
It should be good to use "AWS::Diagram::Canvas" instead of just "Canvas".
And also, this resource seems like the top parent, so I'll change its type to Group.
