### PR TITLE
add functional test for CFn templates

### DIFF
--- a/test/func_test.go
+++ b/test/func_test.go
@@ -119,7 +119,11 @@ func TestFunctionality(t *testing.T) {
 			if err != nil {
 				t.Errorf("Cannot create directory(%s): %v", filepath.Dir(tmpOutputFilename), err)
 			}
-			ctl.CreateDiagramFromYAML(yamlFilename, &tmpOutputFilename)
+			if strings.HasSuffix(file.Name(), "-cfn.yaml") {
+				ctl.CreateDiagramFromCFnTemplate(yamlFilename, &tmpOutputFilename)
+			} else {
+				ctl.CreateDiagramFromYAML(yamlFilename, &tmpOutputFilename)
+			}
 			pngFilename := strings.Replace(yamlFilename, ".yaml", ".png", 1)
 			err := compareTwoImages(pngFilename, tmpOutputFilename)
 			if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Test the sample whose file name ends with `-cfn.yaml` as a CloudFormation template.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
