### PR TITLE
Ignoring DependsOn without string (e.g. ECS containers' DependsOn)

### DIFF
--- a/internal/ctl/cfntemplate.go
+++ b/internal/ctl/cfntemplate.go
@@ -101,6 +101,7 @@ func convertTemplate(cfn_template cft.Template, template *TemplateStruct, ds def
 
 				//related_resource_type does not have "Type". This means it may be a Parameter value
 				if related_resource_type == "" {
+					log.Infof("%s does not have \"Type\".", related)
 					continue
 				}
 
@@ -141,7 +142,10 @@ func findRefs(t map[string]interface{}, fromName string) []string {
 				refs = append(refs, v)
 			case []interface{}:
 				for _, d := range v {
-					refs = append(refs, d.(string))
+					//note: ECS Containers can have "DependsOn", but it should be ignored.
+					if dStr, ok := d.(string); ok {
+						refs = append(refs, dStr)
+					}
 				}
 			default:
 			}


### PR DESCRIPTION
*Issue #, if available:*

If there is ECS containers' "DependsOn", SIGSEGV error occurs.

```
Resources:
  SampleFargateTaskDefinition:
    Type: AWS::ECS::TaskDefinition
    Properties:
      Cpu: 256
      Memory: 512
      NetworkMode: awsvpc
      RequiresCompatibilities:
        - FARGATE
      ContainerDefinitions:
        - Name: container1
          Image: amazonlinux:2
        - Name: cloudwatch
          DependsOn:    ## <---- here
            - ContainerName: container1
              Condition: START
```

*Description of changes:*

 * Ignoring DependsOn without string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
