### PR TITLE
Ensuring a single parent for resources with multiple parents

### DIFF
--- a/internal/ctl/cfntemplate.go
+++ b/internal/ctl/cfntemplate.go
@@ -114,10 +114,10 @@ func convertTemplate(cfn_template cft.Template, template *TemplateStruct, ds def
 
 				//Find parent
 				findParent = true
-				parent := related
-				parents := template.Diagram.Resources[parent]
-				parents.Children = append(parents.Children, logicalId)
-				template.Diagram.Resources[parent] = parents
+				parent_logicalId := related
+				parent_resources := template.Diagram.Resources[parent_logicalId]
+				parent_resources.Children = append(parent_resources.Children, logicalId)
+				template.Diagram.Resources[parent_logicalId] = parent_resources
 			}
 
 			//If there is no parent resource, consider "AWSCloud" as the parent


### PR DESCRIPTION
*Issue #, if available:*
related #9

If a resource has multiple parents (e.g. a TGWAttachment related to both a VPC and a Subnet), the resource is not rendered.
```
Resources:
## VPC and Subnet definitions are omitted.
  VPCAattachment:
    Type: AWS::EC2::TransitGatewayAttachment
    Properties:
      SubnetIds:
        - !Ref SubnetA
      TransitGatewayId: !Ref TGW
      VpcId: !Ref VPCA
      
  VPCBattachment:
    Type: AWS::EC2::TransitGatewayAttachment
    Properties:
      SubnetIds:
        - !Ref SubnetB
      TransitGatewayId: !Ref TGW
      VpcId: !Ref VPCB
```

*Description of changes:*

* If there is a parent-child relationship among the children of a resource ( a resource is their grandparent), it is deleted from grandparent's children resource.

![image](https://github.com/awslabs/diagram-as-code/assets/41433979/0eaeac61-94e5-4331-bd9e-9bcad37c852e)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
