### PR TITLE
Implement handling of resources with multiple grandchildren

### DIFF
--- a/internal/ctl/cfntemplate.go
+++ b/internal/ctl/cfntemplate.go
@@ -167,6 +167,7 @@ func ensureSingleParent(template *TemplateStruct) {
 					grandparent_resources := template.Diagram.Resources[logicalId]
 					grandparent_resources.Children = newChildren
 					template.Diagram.Resources[logicalId] = grandparent_resources
+					resource.Children = newChildren
 					log.Infof("Updated resource %s children: %v", logicalId, newChildren)
 				}
 			}


### PR DESCRIPTION
*Issue #, if available:*

If a resource has multiple grandchildren (e.g. VPC has ENIs in multiple subnets), ENIs sometimes aren't drawn.

*Description of changes:*

 * Update the current grandparent's child resources whenever a grandchild resource is found

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
