### PR TITLE
Add error handling for undefined resource types

### DIFF
--- a/internal/ctl/cfntemplate.go
+++ b/internal/ctl/cfntemplate.go
@@ -108,8 +108,13 @@ func convertTemplate(cfn_template cft.Template, template *TemplateStruct, ds def
 					continue
 				}
 
+				def, ok := ds.Definitions[related_resource_type]
+				if !ok {
+					log.Infof("%s is not defined in the definition file.", related_resource_type)
+					continue
+				}
+
 				//related_resource_type can not have children resources due to the restrict of definition file.
-				def := ds.Definitions[related_resource_type]
 				if !def.CFn.HasChildren {
 					log.Infof("%s cannot have children resource.", related)
 					continue


### PR DESCRIPTION
*Issue #, if available:*

If you use resource types which is undefined in the definition file, SIGSEGV error will occur.

*Description of changes:*

 * Add error handling for undefined resource types


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
