### PR TITLE
change default border color for resource with children

### DIFF
--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -173,6 +173,7 @@ func loadResources(template *TemplateStruct, ds definition.DefinitionStructure, 
 		switch v.Preset {
 		case "BlankGroup":
 			resources[k].SetIconBounds(image.Rect(0, 0, 64, 64))
+			resources[k].SetBorderColor(color.RGBA{0, 0, 0, 0})
 		case "":
 		default:
 			def, ok := ds.Definitions[v.Preset]

--- a/internal/types/horizontal_stack.go
+++ b/internal/types/horizontal_stack.go
@@ -30,7 +30,7 @@ func (v HorizontalStack) Init() Node {
 	}
 	sr.iconImage = image.NewRGBA(v.bindings)
 	sr.iconBounds = image.Rect(0, 0, 0, 0)
-	sr.borderColor = color.RGBA{0, 0, 0, 0}
+	sr.borderColor = &color.RGBA{0, 0, 0, 0}
 	sr.fillColor = color.RGBA{0, 0, 0, 0}
 	sr.label = ""
 	sr.labelColor = &color.RGBA{0, 0, 0, 0}

--- a/internal/types/horizontal_stack_test.go
+++ b/internal/types/horizontal_stack_test.go
@@ -28,7 +28,7 @@ func TestHorizontalStackInit(t *testing.T) {
 		t.Errorf("Incorrect iconBounds: %v", resource.iconBounds)
 	}
 
-	if resource.borderColor != (color.RGBA{0, 0, 0, 0}) {
+	if *resource.borderColor != (color.RGBA{0, 0, 0, 0}) {
 		t.Errorf("Incorrect borderColor: %v", resource.borderColor)
 	}
 

--- a/internal/types/resource.go
+++ b/internal/types/resource.go
@@ -22,7 +22,7 @@ type Resource struct {
 	bindings    *image.Rectangle
 	iconImage   image.Image
 	iconBounds  image.Rectangle
-	borderColor color.RGBA
+	borderColor *color.RGBA
 	fillColor   color.RGBA
 	label       string
 	labelFont   string
@@ -42,16 +42,18 @@ var defaultResourceValues = map[bool]Resource{
 			image.Point{0, 0},
 			image.Point{64, 64},
 		},
-		margin:  &Margin{30, 100, 30, 100},
-		padding: &Padding{0, 0, 0, 0},
+		margin:      &Margin{30, 100, 30, 100},
+		padding:     &Padding{0, 0, 0, 0},
+		borderColor: &color.RGBA{0, 0, 0, 0},
 	},
 	true: { // resource has children and show as Group
 		bindings: &image.Rectangle{
 			image.Point{0, 0},
 			image.Point{320, 190},
 		},
-		margin:  &Margin{20, 15, 20, 15},
-		padding: &Padding{20, 45, 20, 45},
+		margin:      &Margin{20, 15, 20, 15},
+		padding:     &Padding{20, 45, 20, 45},
+		borderColor: &color.RGBA{0, 0, 0, 255},
 	},
 }
 
@@ -60,7 +62,7 @@ func (r Resource) Init() Node {
 	rr.bindings = nil
 	rr.iconImage = image.NewRGBA(image.Rect(0, 0, 0, 0))
 	rr.iconBounds = image.Rect(0, 0, 0, 0)
-	rr.borderColor = color.RGBA{0, 0, 0, 0}
+	rr.borderColor = nil
 	rr.fillColor = color.RGBA{0, 0, 0, 0}
 	rr.label = ""
 	rr.labelFont = ""
@@ -109,7 +111,7 @@ func (r *Resource) GetPadding() Padding {
 }
 
 func (r *Resource) SetBorderColor(borderColor color.RGBA) {
-	r.borderColor = borderColor
+	r.borderColor = &borderColor
 }
 
 func (r *Resource) SetFillColor(fillColor color.RGBA) {
@@ -169,6 +171,9 @@ func (r *Resource) Scale() {
 	}
 	if r.padding == nil {
 		r.padding = defaultResourceValues[hasChildren].padding
+	}
+	if r.borderColor == nil {
+		r.borderColor = defaultResourceValues[hasChildren].borderColor
 	}
 
 	w := r.padding.Left + r.padding.Right

--- a/internal/types/resource_test.go
+++ b/internal/types/resource_test.go
@@ -77,7 +77,7 @@ func TestResource(t *testing.T) {
 	// Test SetBorderColor
 	borderColor := color.RGBA{255, 0, 0, 255}
 	r.SetBorderColor(borderColor)
-	if r.borderColor != borderColor {
+	if *r.borderColor != borderColor {
 		t.Errorf("SetBorderColor: expected borderColor to be %v, got %v", borderColor, r.borderColor)
 	}
 

--- a/internal/types/vertical_stack.go
+++ b/internal/types/vertical_stack.go
@@ -30,7 +30,7 @@ func (h VerticalStack) Init() Node {
 	}
 	sr.iconImage = image.NewRGBA(h.bindings)
 	sr.iconBounds = image.Rect(0, 0, 0, 0)
-	sr.borderColor = color.RGBA{0, 0, 0, 0}
+	sr.borderColor = &color.RGBA{0, 0, 0, 0}
 	sr.fillColor = color.RGBA{0, 0, 0, 0}
 	sr.label = ""
 	sr.labelColor = &color.RGBA{0, 0, 0, 0}

--- a/internal/types/vertical_stack_test.go
+++ b/internal/types/vertical_stack_test.go
@@ -28,7 +28,7 @@ func TestVerticalStackInit(t *testing.T) {
 		t.Errorf("Incorrect iconBounds: %v", resource.iconBounds)
 	}
 
-	if resource.borderColor != (color.RGBA{0, 0, 0, 0}) {
+	if *resource.borderColor != (color.RGBA{0, 0, 0, 0}) {
 		t.Errorf("Incorrect borderColor: %v", resource.borderColor)
 	}
 


### PR DESCRIPTION
*Issue #64

*Description of changes:*
Specifies the border color of resources with children from transparent to black. The border color (transparent) of resources without children remains unchanged.

AWS::ECS::Cluster whose border color is not specified in the definition file is displayed in black as shown below.
![output](https://github.com/awslabs/diagram-as-code/assets/914815/830d21fe-3a7e-4a65-918b-3512251b32b1)