### PR TITLE
Add border line to resources which have children

### DIFF
--- a/internal/ctl/cfntemplate.go
+++ b/internal/ctl/cfntemplate.go
@@ -6,6 +6,7 @@ package ctl
 
 import (
 	"fmt"
+	"image/color"
 	"regexp"
 	"strings"
 
@@ -210,6 +211,11 @@ func associateCFnChildren(template *TemplateStruct, ds definition.DefinitionStru
 			log.Infof("Add child(%s) on %s", child, logicalId)
 
 			resources[logicalId].AddChild(resources[child])
+
+			if def.Border == nil {
+				resources[logicalId].SetBorderColor(color.RGBA{0, 0, 0, 255})
+				resources[logicalId].SetFillColor(color.RGBA{0, 0, 0, 0})
+			}
 		}
 	}
 }


### PR DESCRIPTION
*Issue #, if available:*

There is an issue where the border is not displayed even for resources that have children.

*Description of changes:*

If a resource has children, the border line will be drawn.

```
Resources:
  SampleFargateCluster:
    Type: AWS::ECS::Cluster
```
![ECS1](https://github.com/awslabs/diagram-as-code/assets/41433979/7f15ee27-8b86-482f-9104-cd385679d4bf)

```
Resources:
  SampleFargateCluster:
    Type: AWS::ECS::Cluster

  SampleFargateService:
    Type: AWS::ECS::Service
    Properties:
      Cluster: !Ref SampleFargateCluster
```
![ECS](https://github.com/awslabs/diagram-as-code/assets/41433979/2f3f3f3d-6a6f-49e2-a10a-685e2807070a)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
