### PR TITLE
Add new feature: generating yaml file from CloudFormation template

### DIFF
--- a/cmd/awsdac/main.go
+++ b/cmd/awsdac/main.go
@@ -16,7 +16,8 @@ func main() {
 
 	var outputFile string
 	var verbose bool
-	var cfntemplate bool
+	var cfnTemplate bool
+	var generateYaml bool
 
 	var rootCmd = &cobra.Command{
 		Use:   "awsdac <input filename>",
@@ -38,8 +39,8 @@ func main() {
 
 			inputFile := args[0]
 
-			if cfntemplate {
-				ctl.CreateDiagramFromCFnTemplate(inputFile, &outputFile)
+			if cfnTemplate {
+				ctl.CreateDiagramFromCFnTemplate(inputFile, &outputFile, generateYaml)
 			} else {
 				ctl.CreateDiagramFromYAML(inputFile, &outputFile)
 			}
@@ -49,7 +50,8 @@ func main() {
 
 	rootCmd.PersistentFlags().StringVarP(&outputFile, "output", "o", "output.png", "Output file name")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
-	rootCmd.PersistentFlags().BoolVarP(&cfntemplate, "cfn-template", "", false, "[beta] Create diagram from CloudFormation template")
+	rootCmd.PersistentFlags().BoolVarP(&cfnTemplate, "cfn-template", "", false, "[beta] Create diagram from CloudFormation template")
+	rootCmd.PersistentFlags().BoolVarP(&generateYaml, "yaml", "", false, "[beta] Generate YAML file from CloudFormation template")
 
 	rootCmd.Execute()
 }

--- a/test/func_test.go
+++ b/test/func_test.go
@@ -120,7 +120,7 @@ func TestFunctionality(t *testing.T) {
 				t.Errorf("Cannot create directory(%s): %v", filepath.Dir(tmpOutputFilename), err)
 			}
 			if strings.HasSuffix(file.Name(), "-cfn.yaml") {
-				ctl.CreateDiagramFromCFnTemplate(yamlFilename, &tmpOutputFilename)
+				ctl.CreateDiagramFromCFnTemplate(yamlFilename, &tmpOutputFilename, true)
 			} else {
 				ctl.CreateDiagramFromYAML(yamlFilename, &tmpOutputFilename)
 			}


### PR DESCRIPTION
*Issue #, if available:*
issue  #75

*Description of changes:*

`awsdac` has the new feature of generating yaml file from CloudFormation template.
```
Usage:
  awsdac <input filename> [flags]

Flags:
      --cfn-template    [beta] Create diagram from CloudFormation template
  -h, --help            help for awsdac
  -o, --output string   Output file name (default "output.png")
  -v, --verbose         Enable verbose logging
      --yaml            [beta] Generate YAML file from CloudFormation template
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
