### PR TITLE
Add support for reading YAML data from remote URLs

### DIFF
--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -9,6 +9,7 @@ import (
 	"image/color"
 	"image/png"
 	"os"
+	"strings"
 
 	"github.com/awslabs/diagram-as-code/internal/cache"
 	"github.com/awslabs/diagram-as-code/internal/definition"
@@ -276,4 +277,11 @@ func loadLinks(template *TemplateStruct, resources map[string]types.Node) {
 		resources[v.Target].AddLink(link)
 	}
 
+}
+
+func IsURL(str string) bool {
+	if strings.HasPrefix(str, "http://") || strings.HasPrefix(str, "https://") {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

```
$ go run cmd/awsdac/main.go https://raw.githubusercontent.com/awslabs/diagram-as-code/main/examples/alb-ec2.yaml -o http-input.png
[Completed] AWS infrastructure diagram generated: http-input.png

$ go run cmd/awsdac/main.go https://github.com/awslabs/diagram-as-code/blob/main/examples/alb-ec2.yaml -o http-input-err.png
FATA[0000] yaml: line 211: mapping values are not allowed in this context 
exit status 1
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
