### PR TITLE
Rename yaml to dacfile for easy-understand

### DIFF
--- a/cmd/awsdac/main.go
+++ b/cmd/awsdac/main.go
@@ -42,7 +42,7 @@ func main() {
 			if cfnTemplate {
 				ctl.CreateDiagramFromCFnTemplate(inputFile, &outputFile, generateDacFile)
 			} else {
-				ctl.CreateDiagramFromYAML(inputFile, &outputFile)
+				ctl.CreateDiagramFromDacFile(inputFile, &outputFile)
 			}
 
 		},

--- a/internal/ctl/dacfile.go
+++ b/internal/ctl/dacfile.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func CreateDiagramFromYAML(inputfile string, outputfile *string) {
+func CreateDiagramFromDacFile(inputfile string, outputfile *string) {
 
 	log.Infof("input file path: %s\n", inputfile)
 

--- a/test/func_test.go
+++ b/test/func_test.go
@@ -122,7 +122,7 @@ func TestFunctionality(t *testing.T) {
 			if strings.HasSuffix(file.Name(), "-cfn.yaml") {
 				ctl.CreateDiagramFromCFnTemplate(yamlFilename, &tmpOutputFilename, true)
 			} else {
-				ctl.CreateDiagramFromYAML(yamlFilename, &tmpOutputFilename)
+				ctl.CreateDiagramFromDacFile(yamlFilename, &tmpOutputFilename)
 			}
 			pngFilename := strings.Replace(yamlFilename, ".yaml", ".png", 1)
 			err := compareTwoImages(pngFilename, tmpOutputFilename)


### PR DESCRIPTION
*Issue #, if available:*

Problem of not knowing what file "yaml" refers to

*Description of changes:*

 * Rename yaml to `dacfile (diagram as code file)` for easy-understand

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
