### PR TITLE
Fallback to LiberationSans font

### DIFF
--- a/internal/font/linux.go
+++ b/internal/font/linux.go
@@ -6,4 +6,7 @@
 
 package font
 
-var Paths = []string{"/usr/share/fonts/truetype/msttcorefonts/Arial.ttf"}
+var Paths = []string{
+	"/usr/share/fonts/truetype/msttcorefonts/Arial.ttf",
+	"/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf",
+}

--- a/internal/font/linux.go
+++ b/internal/font/linux.go
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build darwin
-// +build darwin
+//go:build linux
+// +build linux
 
 package font
 
-var Arial string = "/Library/Fonts/Arial Unicode.ttf"
+var Paths = []string{"/usr/share/fonts/truetype/msttcorefonts/Arial.ttf"}

--- a/internal/font/macos.go
+++ b/internal/font/macos.go
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
+//go:build darwin
+// +build darwin
 
 package font
 
-var Arial string = "C:\\Windows\\Fonts\\arial.ttf"
+var Paths = []string{"/Library/Fonts/Arial Unicode.ttf"}

--- a/internal/font/windows.go
+++ b/internal/font/windows.go
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build linux
-// +build linux
+//go:build windows
+// +build windows
 
 package font
 
-var Arial string = "/usr/share/fonts/truetype/msttcorefonts/Arial.ttf"
+var Paths = []string{"C:\\Windows\\Fonts\\arial.ttf"}

--- a/internal/types/group.go
+++ b/internal/types/group.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"errors"
 	"image"
 	"image/color"
 	"io/ioutil"
@@ -290,7 +291,11 @@ func (g *Group) drawLabel(img *image.RGBA, parent *Group) {
 		if parent != nil && parent.labelFont != "" {
 			g.labelFont = parent.labelFont
 		} else {
-			g.labelFont = fontPath.Arial
+			for _, x := range fontPath.Paths {
+				if _, err := os.Stat(x); !errors.Is(err, os.ErrNotExist) {
+					g.labelFont = x
+				}
+			}
 		}
 	}
 	if g.labelColor == nil {

--- a/internal/types/resource.go
+++ b/internal/types/resource.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"errors"
 	"image"
 	"image/color"
 	"io/ioutil"
@@ -328,7 +329,11 @@ func (r *Resource) drawLabel(img *image.RGBA, parent *Resource, hasChild bool) {
 		if parent != nil && parent.labelFont != "" {
 			r.labelFont = parent.labelFont
 		} else {
-			r.labelFont = fontPath.Arial
+			for _, x := range fontPath.Paths {
+				if _, err := os.Stat(x); !errors.Is(err, os.ErrNotExist) {
+					r.labelFont = x
+				}
+			}
 		}
 	}
 	if r.labelColor == nil {


### PR DESCRIPTION
*Issue #12

*Description of changes:*
Many Linux distributions do not provide the MS core fonts and will fall back to Liberationsans if Arial is not present.