### PR TITLE
Update definitions

### DIFF
--- a/definitions/definition-for-aws-icons-light.yaml
+++ b/definitions/definition-for-aws-icons-light.yaml
@@ -2020,6 +2020,61 @@ Definitions:
     CFn:
       HasChildren: false
 
+  AWS::IAM::AccessKey:
+    Type: Resource
+    Icon:
+      Source: ArchitectureIconsPptxMedia
+      Path: "image1447.png"
+    Label:
+      Title: "Long-term security credential"
+      Color: "rgba(0, 0, 0, 255)"
+    CFn:
+      HasChildren: false
+
+  AWS::IAM::GroupPolicy:
+    Type: Resource
+    Icon:
+      Source: ArchitectureIconsPptxMedia
+      Path: "image1437.png"
+    Label:
+      Title: "Permissions"
+      Color: "rgba(0, 0, 0, 255)"
+    CFn:
+      HasChildren: false
+
+  AWS::IAM::InstanceProfile:
+    Type: Resource
+    Icon:
+      Source: ArchitectureIconsPptxMedia
+      Path: "image1437.png"
+    Label:
+      Title: "Permissions"
+      Color: "rgba(0, 0, 0, 255)"
+    CFn:
+      HasChildren: false
+
+  AWS::IAM::ManagedPolicy:
+    Type: Resource
+    Icon:
+      Source: ArchitectureIconsPptxMedia
+      Path: "image1437.png"
+    Label:
+      Title: "Permissions"
+      Color: "rgba(0, 0, 0, 255)"
+    CFn:
+      HasChildren: false
+
+  AWS::IAM::Policy:
+    Type: Resource
+    Icon:
+      Source: ArchitectureIconsPptxMedia
+      Path: "image1437.png"
+    Label:
+      Title: "Permissions"
+      Color: "rgba(0, 0, 0, 255)"
+    CFn:
+      HasChildren: false
+
   AWS::IAM::Role:
     Type: Resource
     Icon:
@@ -2027,6 +2082,39 @@ Definitions:
       Path: "image1441.png"
     Label:
       Title: "Role"
+      Color: "rgba(0, 0, 0, 255)"
+    CFn:
+      HasChildren: false
+
+  AWS::IAM::RolePolicy:
+    Type: Resource
+    Icon:
+      Source: ArchitectureIconsPptxMedia
+      Path: "image1437.png"
+    Label:
+      Title: "Permissions"
+      Color: "rgba(0, 0, 0, 255)"
+    CFn:
+      HasChildren: false
+
+  AWS::IAM::User:
+    Type: Resource
+    Icon:
+      Source: ArchitectureIconsPptxMedia
+      Path: "image124.png"
+    Label:
+      Title: "User"
+      Color: "rgba(0, 0, 0, 255)"
+    CFn:
+      HasChildren: false
+
+  AWS::IAM::UserPolicy:
+    Type: Resource
+    Icon:
+      Source: ArchitectureIconsPptxMedia
+      Path: "image1437.png"
+    Label:
+      Title: "Permissions"
       Color: "rgba(0, 0, 0, 255)"
     CFn:
       HasChildren: false
@@ -2922,6 +3010,28 @@ Definitions:
     CFn:
       HasChildren: false
 
+  AWS::RDS::DBCluster:
+    Type: Resource
+    Icon:
+      Source: ArchitectureIconsPptxMedia
+      Path: "image609.png"
+    Label:
+      Title: "Amazon Aurora"
+      Color: "rgba(0, 0, 0, 255)"
+    CFn:
+      HasChildren: false
+
+  AWS::RDS::DBInstance:
+    Type: Resource
+    Icon:
+      Source: ArchitectureIconsPptxMedia
+      Path: "image675.png"
+    Label:
+      Title: "Amazon RDS instance"
+      Color: "rgba(0, 0, 0, 255)"
+    CFn:
+      HasChildren: false
+
   AWS::RUM:
     Type: Resource
     Icon:
@@ -3154,6 +3264,17 @@ Definitions:
       HasChildren: false
 
   AWS::S3:
+    Type: Resource
+    Icon:
+      Source: ArchitectureIconsPptxMedia
+      Path: "image1621.png"
+    Label:
+      Title: "Amazon Simple Storage Service (Amazon S3)"
+      Color: "rgba(0, 0, 0, 255)"
+    CFn:
+      HasChildren: false
+
+  AWS::S3::Bucket:
     Type: Resource
     Icon:
       Source: ArchitectureIconsPptxMedia
@@ -3407,6 +3528,17 @@ Definitions:
       HasChildren: false
 
   AWS::SecretsManager:
+    Type: Resource
+    Icon:
+      Source: ArchitectureIconsPptxMedia
+      Path: "image1463.png"
+    Label:
+      Title: "AWS Secrets Manager"
+      Color: "rgba(0, 0, 0, 255)"
+    CFn:
+      HasChildren: false
+
+  AWS::SecretsManager::Secret:
     Type: Resource
     Icon:
       Source: ArchitectureIconsPptxMedia

--- a/tools/make-definition-from-pptx-mappings
+++ b/tools/make-definition-from-pptx-mappings
@@ -637,20 +637,20 @@ AWS::GuardDuty::Master
 AWS::GuardDuty::Member
 AWS::GuardDuty::ThreatIntelSet
 AWS::IAM,AWS Identity and Access Management (IAM)
-AWS::IAM::AccessKey
+AWS::IAM::AccessKey,Long-term security credential
 AWS::IAM::Group
-AWS::IAM::GroupPolicy
-AWS::IAM::InstanceProfile
-AWS::IAM::ManagedPolicy
+AWS::IAM::GroupPolicy,Permissions(2)
+AWS::IAM::InstanceProfile,Permissions(2)
+AWS::IAM::ManagedPolicy,Permissions(2)
 AWS::IAM::OIDCProvider
-AWS::IAM::Policy
+AWS::IAM::Policy,Permissions(2)
 AWS::IAM::Role,Role
-AWS::IAM::RolePolicy
+AWS::IAM::RolePolicy,Permissions(2)
 AWS::IAM::SAMLProvider
 AWS::IAM::ServerCertificate
 AWS::IAM::ServiceLinkedRole
-AWS::IAM::User
-AWS::IAM::UserPolicy
+AWS::IAM::User,User
+AWS::IAM::UserPolicy,Permissions(2) 
 AWS::IAM::UserToGroupAddition
 AWS::IAM::VirtualMFADevice
 AWS::IVS,Amazon Interactive Video Service
@@ -1034,9 +1034,9 @@ AWS::RAM::Permission
 AWS::RAM::ResourceShare
 AWS::RDS,Amazon Relational Database Service (Amazon RDS)
 AWS::RDS::CustomDBEngineVersion
-AWS::RDS::DBCluster
+AWS::RDS::DBCluster,Amazon Aurora
 AWS::RDS::DBClusterParameterGroup
-AWS::RDS::DBInstance
+AWS::RDS::DBInstance,Amazon RDS instance
 AWS::RDS::DBParameterGroup
 AWS::RDS::DBProxy
 AWS::RDS::DBProxyEndpoint
@@ -1115,7 +1115,7 @@ AWS::S3::AccessGrant
 AWS::S3::AccessGrantsInstance
 AWS::S3::AccessGrantsLocation
 AWS::S3::AccessPoint
-AWS::S3::Bucket,Bucket
+AWS::S3::Bucket,Amazon Simple Storage Service (Amazon S3)
 AWS::S3::BucketPolicy
 AWS::S3::MultiRegionAccessPoint,Access points
 AWS::S3::MultiRegionAccessPointPolicy
@@ -1211,7 +1211,7 @@ AWS::Scheduler::ScheduleGroup
 AWS::SecretsManager,AWS Secrets Manager
 AWS::SecretsManager::ResourcePolicy
 AWS::SecretsManager::RotationSchedule
-AWS::SecretsManager::Secret
+AWS::SecretsManager::Secret,AWS Secrets Manager
 AWS::SecretsManager::SecretTargetAttachment
 AWS::SecurityHub,AWS Security Hub
 AWS::SecurityHub::AutomationRule


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/diagram-as-code/issues/103
https://github.com/awslabs/diagram-as-code/issues/102

*Description of changes:*

Support the following type:
 * AWS::IAM::User[1]
 * AWS::IAM::Policy
 * AWS::IAM::AccessKey
 * AWS::SecretsManager::Secret
 * AWS::S3::Bucket
 * AWS::RDS::DBCluster
 * AWS::RDS::DBInstance
   etc...

[1] Currently, AWS does not provide "IAM User" icon[2], so I try to match this resource type to "General User" icon.
[2] https://aws.amazon.com/architecture/icons/?nc1=h_ls

![image](https://github.com/awslabs/diagram-as-code/assets/41433979/105d25a8-6b5d-4954-b9aa-1a963c0fccbd)

```
Diagram:
  DefinitionFiles:
     ...
  Resources:
    Canvas:
      Type: AWS::Diagram::Canvas
      Direction: vertical
      Children:
        - AWSCloud
    AWSCloud:
      Type: AWS::Diagram::Cloud
      Direction: vertical
      Preset: AWSCloudNoLogo
      Align: center
      Children:
        - IAMStack
        - Secrets
        - S3
        - Aurora
        - DbInstance
    IAMStack:
      Type: AWS::Diagram::HorizontalStack
      Children:
        - IAMUser
        - IAMPolicy      
        - IAMAccessKey
    IAMUser:
      Type: AWS::IAM::User
    IAMPolicy:
      Type: AWS::IAM::Policy
    IAMAccessKey:
      Type: AWS::IAM::AccessKey      
    S3:
      Type: AWS::S3::Bucket
    Aurora:
      Type: AWS::RDS::DBCluster
    DbInstance:
      Type: AWS::RDS::DBInstance
    Secrets:
      Type: AWS::SecretsManager::Secret
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
