### PR TITLE
chore: add version flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           name="awsdac-${GITHUB_REF##*/}_${{ matrix.os }}-${{ matrix.arch }}"
           mkdir -p "dist/${name}"
-          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -buildvcs=false -ldflags=-w -o "dist/${name}" ./cmd/awsdac
+          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -buildvcs=false -ldflags="-w -X main.version=${GITHUB_REF##*/}" -o "dist/${name}" ./cmd/awsdac
           cp LICENSE README.md "dist/${name}"
           zip -9 -r "dist/${name}.zip" "dist/${name}"
 

--- a/cmd/awsdac/main.go
+++ b/cmd/awsdac/main.go
@@ -12,6 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var version = "dev"
+
 func main() {
 
 	var outputFile string
@@ -20,10 +22,11 @@ func main() {
 	var generateDacFile bool
 
 	var rootCmd = &cobra.Command{
-		Use:   "awsdac <input filename>",
-		Short: "Diagram-as-code for AWS architecture.",
-		Long:  "This command line interface (CLI) tool enables drawing infrastructure diagrams for Amazon Web Services through YAML code.",
-		Args:  cobra.MaximumNArgs(1),
+		Use:     "awsdac <input filename>",
+		Version: version,
+		Short:   "Diagram-as-code for AWS architecture.",
+		Long:    "This command line interface (CLI) tool enables drawing infrastructure diagrams for Amazon Web Services through YAML code.",
+		Args:    cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 
 			if len(args) == 0 {


### PR DESCRIPTION
*Issue #, if available:*

close #89 

*Description of changes:*

In this CR, we add a version flag to show the version of the CLI. The version is embedded at build time with `-ldflags`.

```
> go run cmd/awsdac/main.go --version
awsdac version dev

> go build -ldflags="-w -X main.version=v0.0.1" cmd/awsdac/main.go

> ./main --version
awsdac version v0.0.1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
