### PR TITLE
Add NixOS fonts path

### DIFF
--- a/internal/font/linux.go
+++ b/internal/font/linux.go
@@ -7,9 +7,10 @@
 package font
 
 var Paths = []string{
-	"/usr/share/fonts/truetype/msttcorefonts/Arial.ttf",                // For Ubuntu linux ttf-mscorefonts-installer package.
-	"/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",  // For Ubuntu/Debian Linux fonts-liberation package.
-	"/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf", // For Ubuntu/Debian Linux fonts-liberation2 package.
-	"/usr/share/fonts/liberation-sans/LiberationSans-Regular.ttf",      // For Fedora/AL2023 Linux liberation-sans-fonts package.
-	"/usr/share/fonts/liberation/LiberationSans-Regular.ttf",           // For Alpine/Arch Linux ttf-liberation package.
+	"/usr/share/fonts/truetype/msttcorefonts/Arial.ttf",                 // For Ubuntu linux ttf-mscorefonts-installer package.
+	"/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",   // For Ubuntu/Debian Linux fonts-liberation package.
+	"/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf",  // For Ubuntu/Debian Linux fonts-liberation2 package.
+	"/usr/share/fonts/liberation-sans/LiberationSans-Regular.ttf",       // For Fedora/AL2023 Linux liberation-sans-fonts package.
+	"/usr/share/fonts/liberation/LiberationSans-Regular.ttf",            // For Alpine/Arch Linux ttf-liberation package.
+	"/run/current-system/sw/share/X11/fonts/LiberationSans-Regular.ttf", // For NixOS Linux liberation_ttf package (enable fontDir in fonts options).
 }


### PR DESCRIPTION
The liberation font can't be found on NixOS. Adding the relevant location to those already checked in font/linux.go.

Not relevant to this project but the option fontDir needs to be enabled in NixOS for the referenced directory to be created.

Can confirm this works for me.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
