### PR TITLE
add: multiline feature for labels

### DIFF
--- a/internal/types/resource.go
+++ b/internal/types/resource.go
@@ -268,9 +268,12 @@ func (r *Resource) Scale(parent *Resource) {
 	textHeight := 0
 	if r.label != "" {
 		fontFace := r.prepareFontFace(hasChildren, parent)
-		textBindings, _ := font.BoundString(fontFace, r.label)
-		textWidth = textBindings.Max.X.Ceil() - textBindings.Min.X.Ceil()
-		textHeight = textBindings.Max.Y.Ceil() - textBindings.Min.Y.Ceil()
+		texts := strings.Split(r.label, "\n")
+		for _, line := range texts {
+			textBindings, _ := font.BoundString(fontFace, line)
+			textWidth = max(textWidth, textBindings.Max.X.Ceil() - textBindings.Min.X.Ceil())
+			textHeight += textBindings.Max.Y.Ceil() - textBindings.Min.Y.Ceil()
+		}
 	}
 	if r.bindings == nil {
 		r.bindings = defaultResourceValues(hasChildren).bindings


### PR DESCRIPTION
This should solve https://github.com/awslabs/diagram-as-code/issues/147

For this I split the initial label on newline characters.
Then iterate onto the `drawLabel` code to draw each line.
I increase a `lineOffset` on each round that is responsible for moving lines on the Y axis.
Used a 10 px margin between lines (arbitrary).

For easier review here is a cleaner diff (without the foeach indent to see the code I really changed). 

```diff
diff --git a/internal/types/resource.go b/internal/types/resource.go
index aef103f..bcf2c95 100644
--- a/internal/types/resource.go
+++ b/internal/types/resource.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
+	"strings"
 
 	fontPath "github.com/awslabs/diagram-as-code/internal/font"
 	"github.com/golang/freetype/truetype"
@@ -585,12 +586,17 @@ func (r *Resource) drawMargin(img *image.RGBA) {
 func (r *Resource) drawLabel(img *image.RGBA, parent *Resource, hasChild bool) {
 	face := r.prepareFontFace(hasChild, parent)
 
-	textBindings, _ := font.BoundString(face, r.label)
+	texts := strings.Split(r.label, "\n")
+	lineOffset := 0
+
+	for _, line := range texts {
+	textBindings, _ := font.BoundString(face, line)
 
 	textWidth := textBindings.Max.X.Ceil() - textBindings.Min.X.Ceil()
 	textHeight := textBindings.Max.Y.Ceil() - textBindings.Min.Y.Ceil()
+
 	w := textBindings.Max.X - textBindings.Min.X + fixed.I(1)
-	h := textBindings.Max.Y - textBindings.Min.Y + fixed.I(1)
+	h := textBindings.Max.Y - textBindings.Min.Y + fixed.I(1) + fixed.I(lineOffset)
 
 	p := r.bindings.Min.Add(image.Point{0, r.iconBounds.Max.Y})
 
@@ -605,17 +611,17 @@ func (r *Resource) drawLabel(img *image.RGBA, parent *Resource, hasChild bool) {
 		case "left":
 			p = r.bindings.Min.Add(image.Point{
 				r.iconBounds.Max.X + padding,
-				iconHeight - padding,
+				iconHeight - padding + lineOffset,
 			})
 		case "center":
 			p = r.bindings.Min.Add(image.Point{
 				(r.bindings.Dx() - textWidth) / 2,
-				r.iconBounds.Dy() + iconHeight - padding,
+				r.iconBounds.Dy() + iconHeight - padding + lineOffset,
 			})
 		case "right":
 			p = r.bindings.Min.Add(image.Point{
 				r.iconBounds.Dx() - r.bindings.Dx() - r.iconBounds.Dx() - padding,
-				iconHeight - padding,
+				iconHeight - padding + lineOffset,
 			})
 		}
 		point = fixed.Point26_6{fixed.I(p.X), fixed.I(p.Y)}
@@ -627,5 +633,7 @@ func (r *Resource) drawLabel(img *image.RGBA, parent *Resource, hasChild bool) {
 		Face: face,
 		Dot:  point,
 	}
-	d.DrawString(r.label)
+	d.DrawString(line)
+	lineOffset += textHeight + 10
+	}
 }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.