### PR TITLE
fix: change to recommended subnet presets on examples

### DIFF
--- a/examples/alb-ec2.yaml
+++ b/examples/alb-ec2.yaml
@@ -36,14 +36,14 @@ Diagram:
         - VPCPublicSubnet2
     VPCPublicSubnet1:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - VPCPublicSubnet1Instance
     VPCPublicSubnet1Instance:
       Type: AWS::EC2::Instance
     VPCPublicSubnet2:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - VPCPublicSubnet2Instance
     VPCPublicSubnet2Instance:

--- a/examples/multi-region.yaml
+++ b/examples/multi-region.yaml
@@ -51,14 +51,14 @@ Diagram:
         - OregonVPCPublicSubnet2
     OregonVPCPublicSubnet1:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - OregonVPCPublicSubnet1Instance
     OregonVPCPublicSubnet1Instance:
       Type: AWS::EC2::Instance
     OregonVPCPublicSubnet2:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - OregonVPCPublicSubnet2Instance
     OregonVPCPublicSubnet2Instance:
@@ -97,14 +97,14 @@ Diagram:
         - VirginiaVPCPublicSubnet2
     VirginiaVPCPublicSubnet1:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - VirginiaVPCPublicSubnet1Instance
     VirginiaVPCPublicSubnet1Instance:
       Type: AWS::EC2::Instance
     VirginiaVPCPublicSubnet2:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - VirginiaVPCPublicSubnet2Instance
     VirginiaVPCPublicSubnet2Instance:

--- a/examples/privatelink.yaml
+++ b/examples/privatelink.yaml
@@ -41,14 +41,14 @@ Diagram:
         - VPC1PublicSubnet2
     VPC1PublicSubnet1:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - VPC1PublicSubnet1Instance
     VPC1PublicSubnet1Instance:
       Type: AWS::EC2::Instance
     VPC1PublicSubnet2:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - VPC1PublicSubnet2Instance
     VPC1PublicSubnet2Instance:
@@ -88,14 +88,14 @@ Diagram:
         - VPC2PublicSubnet2
     VPC2PublicSubnet1:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - VPC2PublicSubnet1Instance
     VPC2PublicSubnet1Instance:
       Type: AWS::EC2::Instance
     VPC2PublicSubnet2:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - VPC2PublicSubnet2EmptyResource
     VPC2PublicSubnet2EmptyResource:

--- a/examples/tgw-nwfw.yaml
+++ b/examples/tgw-nwfw.yaml
@@ -49,14 +49,14 @@ Diagram:
         - VPC1TransitSubnet1
     VPC1PublicSubnet1:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - VPC1PublicSubnet1Instance
     VPC1PublicSubnet1Instance:
       Type: AWS::EC2::Instance
     VPC1TransitSubnet1:
       Type: AWS::EC2::Subnet
-      Preset: PrivateSubnet
+      Preset: Private subnet
       Children:
         - VPC1TransitSubnet1Eni
     VPC1TransitSubnet1Eni:
@@ -72,14 +72,14 @@ Diagram:
         - VPC1TransitSubnet2
     VPC1PublicSubnet2:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - VPC1PublicSubnet2Instance
     VPC1PublicSubnet2Instance:
       Type: AWS::EC2::Instance
     VPC1TransitSubnet2:
       Type: AWS::EC2::Subnet
-      Preset: PrivateSubnet
+      Preset: Private subnet
       Children:
         - VPC1TransitSubnet2Eni
     VPC1TransitSubnet2Eni:
@@ -120,7 +120,7 @@ Diagram:
         - VPC2PublicSubnet1
     VPC2TransitSubnet1:
       Type: AWS::EC2::Subnet
-      Preset: PrivateSubnet
+      Preset: Private subnet
       Children:
         - VPC2TransitSubnet1Eni
     VPC2TransitSubnet1Eni:
@@ -128,7 +128,7 @@ Diagram:
       Title: "TGW ENI"
     VPC2PublicSubnet1:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - VPC2PublicSubnet1Instance
     VPC2PublicSubnet1Instance:
@@ -143,14 +143,14 @@ Diagram:
         - VPC2PublicSubnet2
     VPC2PublicSubnet2:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - VPC2PublicSubnet2Instance
     VPC2PublicSubnet2Instance:
       Type: AWS::EC2::Instance
     VPC2TransitSubnet2:
       Type: AWS::EC2::Subnet
-      Preset: PrivateSubnet
+      Preset: Private subnet
       Children:
         - VPC2TransitSubnet2Eni
     VPC2TransitSubnet2Eni:
@@ -191,7 +191,7 @@ Diagram:
         - VPC3FirewallSubnet1
     VPC3TransitSubnet1:
       Type: AWS::EC2::Subnet
-      Preset: PrivateSubnet
+      Preset: Private subnet
       Children:
         - VPC3TransitSubnet1Eni
     VPC3TransitSubnet1Eni:
@@ -199,7 +199,7 @@ Diagram:
       Title: "TGW ENI"
     VPC3FirewallSubnet1:
       Type: AWS::EC2::Subnet
-      Preset: PrivateSubnet
+      Preset: Private subnet
       Title: "Firewall Subnet"
       FillColor: "rgba(150,115,166,75)"
       Children:
@@ -217,7 +217,7 @@ Diagram:
         - VPC3FirewallSubnet2
     VPC3TransitSubnet2:
       Type: AWS::EC2::Subnet
-      Preset: PrivateSubnet
+      Preset: Private subnet
       Children:
         - VPC3TransitSubnet2Eni
     VPC3TransitSubnet2Eni:
@@ -225,7 +225,7 @@ Diagram:
       Title: "TGW ENI"
     VPC3FirewallSubnet2:
       Type: AWS::EC2::Subnet
-      Preset: PrivateSubnet
+      Preset: Private subnet
       Title: "Firewall Subnet"
       FillColor: "rgba(150,115,166,75)"
       Children:

--- a/examples/vpc-natgw.yaml
+++ b/examples/vpc-natgw.yaml
@@ -34,14 +34,14 @@ Diagram:
         - VPCPublicSubnet2
     VPCPublicSubnet1:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - VPCPublicSubnet1NatGateway
     VPCPublicSubnet1NatGateway:
       Type: AWS::EC2::NatGateway
     VPCPublicSubnet2:
       Type: AWS::EC2::Subnet
-      Preset: PublicSubnet
+      Preset: Public subnet
       Children:
         - VPCPublicSubnet2NatGateway
     VPCPublicSubnet2NatGateway:
@@ -54,14 +54,14 @@ Diagram:
         - VPCPrivateSubnet2
     VPCPrivateSubnet1:
       Type: AWS::EC2::Subnet
-      Preset: PrivateSubnet
+      Preset: Private subnet
       Children:
         - VPCPrivateSubnet1Instance
     VPCPrivateSubnet1Instance:
       Type: AWS::EC2::Instance
     VPCPrivateSubnet2:
       Type: AWS::EC2::Subnet
-      Preset: PrivateSubnet
+      Preset: Private subnet
       Children:
         - VPCPrivateSubnet2Instance
     VPCPrivateSubnet2Instance:


### PR DESCRIPTION
*Description of changes:*
- To discontinue `PrivateSubnet` and `PublicSubnet` presets, change examples