### PR TITLE
Adding explicit empty string to definition file

### DIFF
--- a/definitions/definition-for-aws-icons-light.yaml
+++ b/definitions/definition-for-aws-icons-light.yaml
@@ -156,6 +156,9 @@ Definitions:
 
   "Generic group":
     Type: Preset
+    Icon:
+      Source: ""
+      Path: ""
     Border:
       Type: "dashed"
       Color: "rgba(125, 137, 152, 255)"


### PR DESCRIPTION
*Issue
Below nil pointer error was already fixed at https://github.com/awslabs/diagram-as-code/commit/1a1f9853a527002c666baec152cf68c200037271. However, error will still occur when old awsdac command use the this new definition file.


```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10240650c]

goroutine 1 [running]:
github.com/awslabs/diagram-as-code/internal/definition.(*DefinitionStructure).LoadDefinitions.func1(...)
	github.com/awslabs/diagram-as-code/internal/definition/definition_structure.go:39
github.com/awslabs/diagram-as-code/internal/definition.(*DefinitionStructure).LoadDefinitions(0x14000033a20, {0x140001ae180, 0x60})
	github.com/awslabs/diagram-as-code/internal/definition/definition_structure.go:46 +0x26c
github.com/awslabs/diagram-as-code/internal/ctl.loadDefinitionFiles(0x140001a6000?, 0x14000033a20)
	github.com/awslabs/diagram-as-code/internal/ctl/create.go:126 +0x178
github.com/awslabs/diagram-as-code/internal/ctl.CreateDiagramFromDacFile({0x16dcfb7df, 0x9}, 0x140001065f0)
	github.com/awslabs/diagram-as-code/internal/ctl/dacfile.go:57 +0x2d8
main.main.func2(0x1400018e300?, {0x14000106670?, 0x7?, 0x10249fe4d?})
	github.com/awslabs/diagram-as-code/cmd/awsdac/main.go:62 +0xa0
github.com/spf13/cobra.(*Command).execute(0x14000190308, {0x14000136010, 0x1, 0x1})
	github.com/spf13/cobra@v1.8.0/command.go:987 +0x81c
github.com/spf13/cobra.(*Command).ExecuteC(0x14000190308)
	github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.8.0/command.go:1039
main.main()
	github.com/awslabs/diagram-as-code/cmd/awsdac/main.go:73 +0x2a4
```


*Description of changes:*
- To preserve forward compatibility, add empty string to definition file for avoiding nil pointer issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
