### PR TITLE
fix: enable to recieve URL as an input

### DIFF
--- a/cmd/awsdac/main.go
+++ b/cmd/awsdac/main.go
@@ -38,9 +38,12 @@ func main() {
 			}
 
 			inputFile := args[0]
-			if _, err := os.Stat(inputFile); os.IsNotExist(err) {
-				fmt.Printf("awsdac: Input file '%s' does not exist.\n", inputFile)
-				os.Exit(1)
+			if !ctl.IsURL(inputFile) {
+
+				if _, err := os.Stat(inputFile); os.IsNotExist(err) {
+					fmt.Printf("awsdac: Input file '%s' does not exist.\n", inputFile)
+					os.Exit(1)
+				}
 			}
 
 			return nil


### PR DESCRIPTION
*Issue #, if available:*

[#180](https://github.com/awslabs/diagram-as-code/issues/180)

*Description of changes:*
You can specify a raw URL as an input.
```
$ go run cmd/awsdac/main.go https://raw.githubusercontent.com/awslabs/diagram-as-code/main/examples/alb-ec2.yaml
[Completed] AWS infrastructure diagram generated: output.png
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
