### PR TITLE
add: cli option for override definition file

### DIFF
--- a/.github/workflows/func_test.yaml
+++ b/.github/workflows/func_test.yaml
@@ -33,7 +33,6 @@ jobs:
 
       - name: Functional tests
         run: |
-          find ./examples/ -name *.yaml | xargs -I_ yq -i '.Diagram.DefinitionFiles[0].Type="LocalFile" | del(.Diagram.DefinitionFiles[0].Url) | .Diagram.DefinitionFiles[0].LocalFile="../definitions/definition-for-aws-icons-light.yaml"' _
           go test -v ./test/...
 
       - if: failure()

--- a/cmd/awsdac/main.go
+++ b/cmd/awsdac/main.go
@@ -20,6 +20,7 @@ func main() {
 	var verbose bool
 	var cfnTemplate bool
 	var generateDacFile bool
+	var overrideDefFile string
 
 	var rootCmd = &cobra.Command{
 		Use:     "awsdac <input filename>",
@@ -62,7 +63,7 @@ func main() {
 			if cfnTemplate {
 				ctl.CreateDiagramFromCFnTemplate(inputFile, &outputFile, generateDacFile)
 			} else {
-				ctl.CreateDiagramFromDacFile(inputFile, &outputFile)
+				ctl.CreateDiagramFromDacFile(inputFile, &outputFile, overrideDefFile)
 			}
 
 		},
@@ -72,6 +73,8 @@ func main() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	rootCmd.PersistentFlags().BoolVarP(&cfnTemplate, "cfn-template", "c", false, "[beta] Create diagram from CloudFormation template")
 	rootCmd.PersistentFlags().BoolVarP(&generateDacFile, "dac-file", "d", false, "[beta] Generate YAML file in dac (diagram-as-code) format from CloudFormation template")
+	rootCmd.PersistentFlags().StringVarP(&overrideDefFile, "override-def-file", "", "", "For testing purpose, override DefinitionFiles to another url/local file")
+
 
 	rootCmd.Execute()
 }

--- a/internal/ctl/dacfile.go
+++ b/internal/ctl/dacfile.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func CreateDiagramFromDacFile(inputfile string, outputfile *string) {
+func CreateDiagramFromDacFile(inputfile string, outputfile *string, overrideDefFile string) {
 
 	log.Infof("input file path: %s\n", inputfile)
 
@@ -54,7 +54,28 @@ func CreateDiagramFromDacFile(inputfile string, outputfile *string) {
 	var resources map[string]*types.Resource = make(map[string]*types.Resource)
 
 	log.Info("Load DefinitionFiles section")
-	loadDefinitionFiles(&template, &ds)
+	if overrideDefFile != "" {
+		var overrideDefTemplate TemplateStruct
+		if IsURL(overrideDefFile) {
+			log.Infof("As given overrideDefFile, use %s as URL instead of %v", overrideDefFile, &template.DefinitionFiles)
+			var defFile = DefinitionFile{
+				Type: "URL",
+				Url: overrideDefFile,
+			}
+			overrideDefTemplate.Diagram.DefinitionFiles = append(overrideDefTemplate.Diagram.DefinitionFiles, defFile)
+		} else {
+			log.Infof("As given overrideDefFile, use %s as LocalFile instead of %v", overrideDefFile, &template.DefinitionFiles)
+			var defFile = DefinitionFile{
+				Type: "LocalFile",
+				LocalFile: overrideDefFile,
+			}
+			overrideDefTemplate.Diagram.DefinitionFiles = append(overrideDefTemplate.Diagram.DefinitionFiles, defFile)
+		}
+		loadDefinitionFiles(&overrideDefTemplate, &ds)
+		log.Infof("overrideDefTemplate: %+v", overrideDefTemplate)
+	} else {
+		loadDefinitionFiles(&template, &ds)
+	}
 
 	log.Info("Load Resources section")
 	loadResources(&template, ds, resources)

--- a/test/func_test.go
+++ b/test/func_test.go
@@ -124,7 +124,7 @@ func TestFunctionality(t *testing.T) {
 			if strings.HasSuffix(file.Name(), "-cfn.yaml") {
 				ctl.CreateDiagramFromCFnTemplate(yamlFilename, &tmpOutputFilename, true)
 			} else {
-				ctl.CreateDiagramFromDacFile(yamlFilename, &tmpOutputFilename)
+				ctl.CreateDiagramFromDacFile(yamlFilename, &tmpOutputFilename, "../definitions/definition-for-aws-icons-light.yaml")
 			}
 			pngFilename := strings.Replace(yamlFilename, ".yaml", ".png", 1)
 			tmpOutputDiffFilename := fmt.Sprintf("%s/%s", tmpOutputDir, strings.Replace(file.Name(), ".yaml", "-diff.png", 1))


### PR DESCRIPTION
Related #170, Adding CLI options for testing with Go templates.
We sometime temporarily replace URL with a local definition file in examples for testing purpose, but we will modify it so that it can be overridden with options.