### PR TITLE
fix: return an error in case of circular reference (#35)

### DIFF
--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -102,7 +102,10 @@ type LinkLabel struct {
 func createDiagram(resources map[string]*types.Resource, outputfile *string) {
 
 	log.Info("--- Draw diagram ---")
-	resources["Canvas"].Scale(nil)
+	err := resources["Canvas"].Scale(nil, nil)
+	if err != nil {
+		log.Fatalf("Error scaling diagram: %v", err)
+	}
 	resources["Canvas"].ZeroAdjust()
 	img := resources["Canvas"].Draw(nil, nil)
 

--- a/internal/types/resource_test.go
+++ b/internal/types/resource_test.go
@@ -4,6 +4,7 @@ import (
 	"image"
 	"image/color"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -12,7 +13,7 @@ func TestResource(t *testing.T) {
 	r := new(Resource).Init()
 
 	// Test resource has not children
-	r.Scale(nil)
+	r.Scale(nil, nil)
 	if r.GetBindings() != image.Rect(0, 0, 0, 0) {
 		t.Errorf("Init: expected bindings to be (0, 0, 0, 0), got %v", r.GetBindings())
 	}
@@ -30,7 +31,7 @@ func TestResource(t *testing.T) {
 	r2 := new(Resource).Init()
 	r3 := new(Resource).Init()
 	r2.AddChild(r3)
-	r2.Scale(nil)
+	r2.Scale(nil, nil)
 	if r2.GetMargin() != (Margin{20, 15, 20, 15}) {
 		t.Errorf("Init: expected margin to be (30, 100, 30, 100), got %v", r2.GetMargin())
 	}
@@ -118,5 +119,227 @@ func TestResource(t *testing.T) {
 	}
 	if !r.IsDrawn() {
 		t.Error("Draw: drawn should be true after drawing")
+	}
+}
+
+
+func TestResourceCycleDetection(t *testing.T) {
+	// Define test cases using a table-driven approach
+	testCases := []struct {
+		name           string
+		setupResources func() *Resource
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name: "DirectCycle",
+			setupResources: func() *Resource {
+				r1 := new(Resource).Init()
+				r1.label = "Resource1"
+				r1.AddChild(r1) // Create a direct cycle: r1 -> r1
+
+				return r1
+			},
+			expectError:   true,
+			errorContains: "Cycle detected in resource tree",
+		},
+		{
+			name: "IndirectCycle",
+			setupResources: func() *Resource {
+				r1 := new(Resource).Init()
+				r2 := new(Resource).Init()
+				r1.label = "Resource1"
+				r2.label = "Resource2"
+				r1.AddChild(r2)
+				r2.AddChild(r1) // Create an indirect cycle: r1 -> r2 -> r1
+				return r1
+			},
+			expectError:   true,
+			errorContains: "Cycle detected in resource tree",
+		},
+		{
+			name: "LongerCycle",
+			setupResources: func() *Resource {
+				r1 := new(Resource).Init()
+				r2 := new(Resource).Init()
+				r3 := new(Resource).Init()
+				r1.label = "Resource1"
+				r2.label = "Resource2"
+				r3.label = "Resource3"
+				r1.AddChild(r2)
+				r2.AddChild(r3)
+				r3.AddChild(r1) // Create a cycle: r1 -> r2 -> r3 -> r1
+				return r1
+			},
+			expectError:   true,
+			errorContains: "Cycle detected in resource tree",
+		},
+		{
+			name: "NoCycle",
+			setupResources: func() *Resource {
+				r1 := new(Resource).Init()
+				r2 := new(Resource).Init()
+				r3 := new(Resource).Init()
+				r4 := new(Resource).Init()
+				r1.label = "Root"
+				r2.label = "Child1"
+				r3.label = "Child2"
+				r4.label = "Grandchild"
+				r1.AddChild(r2)
+				r1.AddChild(r3)
+				r2.AddChild(r4)
+				return r1
+			},
+			expectError: false,
+		},
+		{
+			name: "NoCycleWithBorderChildren",
+			setupResources: func() *Resource {
+				parent := new(Resource).Init()
+				child := new(Resource).Init()
+				borderChild := new(Resource).Init()
+				parent.label = "Parent"
+				child.label = "Child"
+				borderChild.label = "BorderChild"
+				parent.AddChild(child)
+				parent.AddBorderChild(&BorderChild{
+					Position: 8, // South position
+					Resource: borderChild,
+				})
+				return parent
+			},
+			expectError: false,
+		},
+		{
+			name: "DirectCycleWithBorderChild",
+			setupResources: func() *Resource {
+				parent := new(Resource).Init()
+				child := new(Resource).Init()
+				borderChild := new(Resource).Init()
+				parent.label = "Parent"
+				child.label = "Child"
+				borderChild.label = "BorderChild"
+				parent.AddChild(child)
+				parent.AddBorderChild(&BorderChild{
+					Position: 8, // South position
+					Resource: borderChild,
+				})
+				borderChild.AddBorderChild(&BorderChild{
+					Position: 8, // South position
+					Resource: borderChild,
+				}) // Create an direct cycle: borderChild -> borderChild
+				return parent
+			},
+			expectError:   true,
+			errorContains: "Cycle detected in resource tree",
+		},
+		{
+			name: "NoCycleMultipleBorderChildren",
+			setupResources: func() *Resource {
+				parent := new(Resource).Init()
+				child := new(Resource).Init()
+				borderChild1 := new(Resource).Init()
+				borderChild2 := new(Resource).Init()
+				parent.label = "Parent"
+				child.label = "Child"
+				borderChild1.label = "BorderChild1"
+				borderChild2.label = "BorderChild2"
+				parent.AddChild(child)
+				parent.AddBorderChild(&BorderChild{
+					Position: 0, // North position
+					Resource: borderChild1,
+				})
+				parent.AddBorderChild(&BorderChild{
+					Position: 8, // South position
+					Resource: borderChild2,
+				})
+				return parent
+			},
+			expectError: false,
+		},
+		{
+			name: "IndirectCycleMultipleBorderChildren",
+			setupResources: func() *Resource {
+				parent := new(Resource).Init()
+				child := new(Resource).Init()
+				borderChild1 := new(Resource).Init()
+				borderChild2 := new(Resource).Init()
+				parent.label = "Parent"
+				child.label = "Child"
+				borderChild1.label = "BorderChild1"
+				borderChild2.label = "BorderChild2"
+				parent.AddChild(child)
+				parent.AddBorderChild(&BorderChild{
+					Position: 0, // North position
+					Resource: borderChild1,
+				})
+				borderChild1.AddBorderChild(&BorderChild{
+					Position: 8, // South position
+					Resource: borderChild2,
+				})
+				borderChild2.AddBorderChild(&BorderChild{
+					Position: 0, // North position
+					Resource: borderChild1,
+				}) // Create an indirect cycle: r1 -> r2 -> r1
+				return parent
+			},
+			expectError:   true,
+			errorContains: "Cycle detected in resource tree",
+		},
+		{
+			name: "LongerCycleMultipleBorderChildren",
+			setupResources: func() *Resource {
+				parent := new(Resource).Init()
+				child := new(Resource).Init()
+				borderChild1 := new(Resource).Init()
+				borderChild2 := new(Resource).Init()
+				borderChild3 := new(Resource).Init()
+				parent.label = "Parent"
+				child.label = "Child"
+				borderChild1.label = "BorderChild1"
+				borderChild2.label = "BorderChild2"
+				borderChild3.label = "BorderChild3"
+				parent.AddChild(child)
+				parent.AddBorderChild(&BorderChild{
+					Position: 0, // North position
+					Resource: borderChild1,
+				})
+				borderChild1.AddBorderChild(&BorderChild{
+					Position: 8, // South position
+					Resource: borderChild2,
+				})
+				borderChild2.AddBorderChild(&BorderChild{
+					Position: 0, // North position
+					Resource: borderChild3,
+				})
+				borderChild3.AddBorderChild(&BorderChild{
+					Position: 8, // South position
+					Resource: borderChild1,
+				}) // Create a cycle: r1 -> r2 -> r3 -> r1
+				return parent
+			},
+			expectError:   true,
+			errorContains: "Cycle detected in resource tree",
+		},
+	}
+
+	// Run all test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := tc.setupResources()
+			err := root.Scale(nil, nil)
+
+			if tc.expectError && err == nil {
+				t.Error("Expected cycle detection error, but got nil")
+			} else if !tc.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if tc.expectError && err != nil && tc.errorContains != "" {
+				if msg := err.Error(); !strings.Contains(msg, tc.errorContains) {
+					t.Errorf("Expected error message to contain %q, got %q", tc.errorContains, msg)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
*Issue #35*

*Description of changes:*

A map recording visited Resources was added as an argument to the Scale () method of the Resource structure.  
This map detects circular references, and the Scale () method returns an error.