### PR TITLE
Fix func test override def

### DIFF
--- a/cmd/awsdac/main.go
+++ b/cmd/awsdac/main.go
@@ -62,7 +62,10 @@ func main() {
 			inputFile := args[0]
 
 			if cfnTemplate {
-				ctl.CreateDiagramFromCFnTemplate(inputFile, &outputFile, generateDacFile)
+				opts := ctl.CreateOptions{
+					OverrideDefFile: overrideDefFile,
+				}
+				ctl.CreateDiagramFromCFnTemplate(inputFile, &outputFile, generateDacFile, &opts)
 			} else {
 				opts := ctl.CreateOptions{
 					IsGoTemplate: isGoTemplate,

--- a/cmd/awsdac/main.go
+++ b/cmd/awsdac/main.go
@@ -64,7 +64,11 @@ func main() {
 			if cfnTemplate {
 				ctl.CreateDiagramFromCFnTemplate(inputFile, &outputFile, generateDacFile)
 			} else {
-				ctl.CreateDiagramFromDacFile(inputFile, &outputFile, isGoTemplate, overrideDefFile)
+				opts := ctl.CreateOptions{
+					IsGoTemplate: isGoTemplate,
+					OverrideDefFile: overrideDefFile,
+				}
+				ctl.CreateDiagramFromDacFile(inputFile, &outputFile, &opts)
 			}
 
 		},

--- a/internal/ctl/cfntemplate.go
+++ b/internal/ctl/cfntemplate.go
@@ -47,7 +47,7 @@ var template = TemplateStruct{
 	},
 }
 
-func CreateDiagramFromCFnTemplate(inputfile string, outputfile *string, generateDacFile bool) {
+func CreateDiagramFromCFnTemplate(inputfile string, outputfile *string, generateDacFile bool, opts *CreateOptions) {
 
 	log.Infof("input file path: %s\n", inputfile)
 
@@ -79,7 +79,28 @@ func CreateDiagramFromCFnTemplate(inputfile string, outputfile *string, generate
 	var resources map[string]*types.Resource = make(map[string]*types.Resource)
 
 	log.Info("--- Load DefinitionFiles section ---")
-	loadDefinitionFiles(&template, &ds)
+        if opts.OverrideDefFile != "" {
+                var overrideDefTemplate TemplateStruct
+                if IsURL(opts.OverrideDefFile) {
+                        log.Infof("As given overrideDefFile, use %s as URL instead of %v", opts.OverrideDefFile, &template.DefinitionFiles)
+                        var defFile = DefinitionFile{
+                                Type: "URL",
+                                Url: opts.OverrideDefFile,
+                        }
+                        overrideDefTemplate.Diagram.DefinitionFiles = append(overrideDefTemplate.Diagram.DefinitionFiles, defFile)
+                } else {
+                        log.Infof("As given overrideDefFile, use %s as LocalFile instead of %v", opts.OverrideDefFile, &template.DefinitionFiles)
+                        var defFile = DefinitionFile{
+                                Type: "LocalFile",
+                                LocalFile: opts.OverrideDefFile,
+                        }
+                        overrideDefTemplate.Diagram.DefinitionFiles = append(overrideDefTemplate.Diagram.DefinitionFiles, defFile)
+                }
+                loadDefinitionFiles(&overrideDefTemplate, &ds)
+                log.Infof("overrideDefTemplate: %+v", overrideDefTemplate)
+        } else {
+                loadDefinitionFiles(&template, &ds)
+        }
 
 	log.Info("--- Convert CloudFormation template to diagram structures ---")
 	convertTemplate(cfn_template, &template, ds)

--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -99,6 +99,11 @@ type LinkLabel struct {
 	Font  *string `yaml:"Font"`
 }
 
+type CreateOptions struct {
+	IsGoTemplate bool
+	OverrideDefFile string
+}
+
 func createDiagram(resources map[string]*types.Resource, outputfile *string) {
 
 	log.Info("--- Draw diagram ---")
@@ -462,3 +467,5 @@ func IsURL(str string) bool {
 	}
 	return false
 }
+
+

--- a/internal/ctl/dacfile.go
+++ b/internal/ctl/dacfile.go
@@ -59,7 +59,7 @@ func processTemplate(templateData []byte) ([]byte, error) {
 	return processed.Bytes(), nil
 }
 
-func CreateDiagramFromDacFile(inputfile string, outputfile *string, isGoTemplate bool, overrideDefFile string) {
+func CreateDiagramFromDacFile(inputfile string, outputfile *string, opts *CreateOptions) {
 
 	log.Infof("input file path: %s\n", inputfile)
 
@@ -73,7 +73,7 @@ func CreateDiagramFromDacFile(inputfile string, outputfile *string, isGoTemplate
 
 	// Process the template with variables
 	var processedData []byte
-	if isGoTemplate {
+	if opts.IsGoTemplate {
 		processedData, err = processTemplate(data)
 		if processedData != nil {
 			log.Infof("processed template: \n%s", string(processedData))
@@ -88,7 +88,7 @@ func CreateDiagramFromDacFile(inputfile string, outputfile *string, isGoTemplate
 	// Unmarshal the processed YAML
 	err = yaml.Unmarshal(processedData, &template)
 	if err != nil {
-		if ! isGoTemplate {
+		if ! opts.IsGoTemplate {
 			log.Warn("Is this file a template, containing template control syntax such as {{ that according to text/template package? If so, add the -t (--tempate) option.")
 		}
 		log.Fatal(err)
@@ -98,20 +98,20 @@ func CreateDiagramFromDacFile(inputfile string, outputfile *string, isGoTemplate
 	var resources map[string]*types.Resource = make(map[string]*types.Resource)
 
 	log.Info("Load DefinitionFiles section")
-	if overrideDefFile != "" {
+	if opts.OverrideDefFile != "" {
 		var overrideDefTemplate TemplateStruct
-		if IsURL(overrideDefFile) {
-			log.Infof("As given overrideDefFile, use %s as URL instead of %v", overrideDefFile, &template.DefinitionFiles)
+		if IsURL(opts.OverrideDefFile) {
+			log.Infof("As given overrideDefFile, use %s as URL instead of %v", opts.OverrideDefFile, &template.DefinitionFiles)
 			var defFile = DefinitionFile{
 				Type: "URL",
-				Url: overrideDefFile,
+				Url: opts.OverrideDefFile,
 			}
 			overrideDefTemplate.Diagram.DefinitionFiles = append(overrideDefTemplate.Diagram.DefinitionFiles, defFile)
 		} else {
-			log.Infof("As given overrideDefFile, use %s as LocalFile instead of %v", overrideDefFile, &template.DefinitionFiles)
+			log.Infof("As given overrideDefFile, use %s as LocalFile instead of %v", opts.OverrideDefFile, &template.DefinitionFiles)
 			var defFile = DefinitionFile{
 				Type: "LocalFile",
-				LocalFile: overrideDefFile,
+				LocalFile: opts.OverrideDefFile,
 			}
 			overrideDefTemplate.Diagram.DefinitionFiles = append(overrideDefTemplate.Diagram.DefinitionFiles, defFile)
 		}

--- a/test/func_test.go
+++ b/test/func_test.go
@@ -121,11 +121,14 @@ func TestFunctionality(t *testing.T) {
 				t.Errorf("Cannot create directory(%s): %v", tmpOutputDir, err)
 			}
 			tmpOutputFilename := fmt.Sprintf("%s/%s", tmpOutputDir, strings.Replace(file.Name(), ".yaml", ".png", 1))
+			opts := ctl.CreateOptions {
+				IsGoTemplate:  strings.HasSuffix(file.Name(), "-tmpl.yaml"),
+				OverrideDefFile: "../definitions/definition-for-aws-icons-light.yaml",
+			}
 			if strings.HasSuffix(file.Name(), "-cfn.yaml") {
-				ctl.CreateDiagramFromCFnTemplate(yamlFilename, &tmpOutputFilename, true)
+				ctl.CreateDiagramFromCFnTemplate(yamlFilename, &tmpOutputFilename, true, &opts)
 			} else {
-				isGoTemplate := strings.HasSuffix(file.Name(), "-tmpl.yaml")
-				ctl.CreateDiagramFromDacFile(yamlFilename, &tmpOutputFilename, isGoTemplate, "../definitions/definition-for-aws-icons-light.yaml")
+				ctl.CreateDiagramFromDacFile(yamlFilename, &tmpOutputFilename, &opts)
 			}
 			pngFilename := strings.Replace(yamlFilename, ".yaml", ".png", 1)
 			tmpOutputDiffFilename := fmt.Sprintf("%s/%s", tmpOutputDir, strings.Replace(file.Name(), ".yaml", "-diff.png", 1))


### PR DESCRIPTION
*Issue #
- Some [GitHub Actionts](https://github.com/awslabs/diagram-as-code/actions/runs/15082763330/job/42401536435)  failed with "Too Many requests" downloading definition file from GitHub.

*Description of changes:*
- also use overrideDefFile option for CFn testing to prevent the download of definition files.