### PR TITLE
fix: decode yaml file strictly and add warnings

### DIFF
--- a/internal/ctl/dacfile.go
+++ b/internal/ctl/dacfile.go
@@ -87,7 +87,9 @@ func CreateDiagramFromDacFile(inputfile string, outputfile *string, opts *Create
 	}
 
 	// Unmarshal the processed YAML
-	err = yaml.Unmarshal(processedData, &template)
+	dec := yaml.NewDecoder(bytes.NewReader(processedData))
+	dec.KnownFields(true)
+	err = dec.Decode(&template)
 	if err != nil {
 		if !opts.IsGoTemplate && slices.Contains(processedData, '{') {
 			log.Warn("Is this file a template, containing template control syntax such as {{ that according to text/template package? If so, add the -t (--tempate) option.")

--- a/internal/types/link.go
+++ b/internal/types/link.go
@@ -406,6 +406,8 @@ func (l *Link) Draw(img *image.RGBA) {
 			l.drawLabel(img, l.TargetPosition, l.Target, l.Source, targetPt, sourcePt, "Left", l.Labels.TargetRight)
 			l.drawLabel(img, l.TargetPosition, l.Target, l.Source, targetPt, sourcePt, "Right", l.Labels.TargetLeft)
 		}
+	} else {
+		log.Fatalf("Unknown type: %s", l.Type)
 	}
 	l.drawn = true
 }


### PR DESCRIPTION
This reverts commit 4ee65bb11b44f36570c5e446b47b0a24b7595faf.

*Issue #, if available:*
- YAML files containing unknown fields would be processed without errors, making configuration mistakes difficult to detect
- Typos and misconfigurations in YAML files could go unnoticed, leading to failed to command with panic

*Description of changes:*
- Replaced yaml.Unmarshal() with yaml.NewDecoder() using KnownFields(true) option
- Enhanced validation to detect and warn about unknown fields in YAML files
- Improved early detection of configuration errors through stricter YAML parsing