### PR TITLE
Add CI support for awsdac-mcp-server

### DIFF
--- a/.github/workflows/func_test.yaml
+++ b/.github/workflows/func_test.yaml
@@ -35,6 +35,9 @@ jobs:
         run: |
           go test -v ./test/...
 
+      - name: Build awsdac-mcp-server
+        run: go build -v ./cmd/awsdac-mcp-server
+
       - if: failure()
         run: echo "Check artifacts https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID#artifacts"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         os: ['linux', 'darwin', 'windows']
         arch: ['amd64', '386', 'arm', 'arm64']
+        binary: ['awsdac', 'awsdac-mcp-server']
         exclude:
           - os: 'darwin'
             arch: '386'
@@ -37,15 +38,15 @@ jobs:
 
       - name: Build
         run: |
-          name="awsdac-${GITHUB_REF##*/}_${{ matrix.os }}-${{ matrix.arch }}"
+          name="${{ matrix.binary }}-${GITHUB_REF##*/}_${{ matrix.os }}-${{ matrix.arch }}"
           mkdir -p "dist/${name}"
-          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -buildvcs=false -ldflags="-w -X main.version=${GITHUB_REF##*/}" -o "dist/${name}" ./cmd/awsdac
+          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -buildvcs=false -ldflags="-w -X main.version=${GITHUB_REF##*/}" -o "dist/${name}" ./cmd/${{ matrix.binary }}
           cp LICENSE README.md "dist/${name}"
           zip -9 -r "dist/${name}.zip" "dist/${name}"
 
       - uses: actions/upload-artifact@v4.4.0
         with:
-          name: dist-${{ matrix.os }}-${{ matrix.arch }}
+          name: dist-${{ matrix.binary }}-${{ matrix.os }}-${{ matrix.arch }}
           path: ./dist/*.zip
 
   release:

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -32,4 +32,9 @@ jobs:
           sudo apt-get install -y ttf-mscorefonts-installer
 
       - name: Unit tests
-        run: go test -v ./internal/...
+        run: |
+          go test -v ./internal/...
+          go test -v ./cmd/awsdac-mcp-server/...
+
+      - name: Build awsdac-mcp-server
+        run: go build -v ./cmd/awsdac-mcp-server


### PR DESCRIPTION
This PR adds CI support for the awsdac-mcp-server component:

## Changes
- Add MCP server build step to unit and functional test workflows
- Add MCP server tests to unit test workflow  
- Update release workflow to build both awsdac and awsdac-mcp-server binaries
- Include both binaries in release artifacts

## Testing
- Unit tests now run for both ./internal/... and ./cmd/awsdac-mcp-server/...
- Both binaries are built and tested in CI
- Release workflow creates artifacts for both awsdac and awsdac-mcp-server

The CI will automatically run when this PR is created to validate the changes.