### PR TITLE
Add Go embedded font (goregular) as default fallback font

### DIFF
--- a/internal/font/linux.go
+++ b/internal/font/linux.go
@@ -13,4 +13,5 @@ var Paths = []string{
 	"/usr/share/fonts/liberation-sans/LiberationSans-Regular.ttf",       // For Fedora/AL2023 Linux liberation-sans-fonts package.
 	"/usr/share/fonts/liberation/LiberationSans-Regular.ttf",            // For Alpine/Arch Linux ttf-liberation package.
 	"/run/current-system/sw/share/X11/fonts/LiberationSans-Regular.ttf", // For NixOS Linux liberation_ttf package (enable fontDir in fonts options).
+	"goregular", // As the default font, uses golang.org/x/image/font/gofont/goregular. For more information about this font, go to: https://go.dev/blog/go-fonts
 }

--- a/internal/font/macos.go
+++ b/internal/font/macos.go
@@ -6,4 +6,7 @@
 
 package font
 
-var Paths = []string{"/Library/Fonts/Arial Unicode.ttf"}
+var Paths = []string{
+	"/Library/Fonts/Arial Unicode.ttf",
+	"goregular", // As the default font, uses golang.org/x/image/font/gofont/goregular. For more information about this font, go to: https://go.dev/blog/go-fonts
+}

--- a/internal/font/windows.go
+++ b/internal/font/windows.go
@@ -6,4 +6,7 @@
 
 package font
 
-var Paths = []string{"C:\\Windows\\Fonts\\arial.ttf"}
+var Paths = []string{
+	"C:\\Windows\\Fonts\\arial.ttf",
+	"goregular", // As the default font, uses golang.org/x/image/font/gofont/goregular. For more information about this font, go to: https://go.dev/blog/go-fonts
+}

--- a/internal/types/resource.go
+++ b/internal/types/resource.go
@@ -240,6 +240,9 @@ func (r *Resource) AddBorderChild(borderChild *BorderChild) error {
 
 func (r *Resource) prepareFontFace(hasChild bool, parent *Resource) (font.Face, error) {
 	if r.labelFont == "" {
+		if parent != nil {
+			log.Infof("parent labelFont: %s", r.labelFont)
+		}
 		if parent != nil && parent.labelFont != "" {
 			r.labelFont = parent.labelFont
 		} else {
@@ -251,6 +254,7 @@ func (r *Resource) prepareFontFace(hasChild bool, parent *Resource) (font.Face, 
 			}
 		}
 	}
+	log.Infof("labelFont: %s", r.labelFont)
 	if r.labelColor == nil {
 		if parent != nil && parent.labelColor != nil {
 			r.labelColor = parent.labelColor
@@ -324,12 +328,12 @@ func (r *Resource) Scale(parent *Resource, visited map[*Resource]bool) error {
 	log.Infof("hasIcon: %t\n", hasIcon)
 	textWidth := 0
 	textHeight := 0
+	fontFace, err := r.prepareFontFace(hasChildren, parent)
+	if err != nil {
+		return fmt.Errorf("failed to prepare font face: %w", err)
+	}
 	if r.label != "" {
 		textHeight = 10
-		fontFace, err := r.prepareFontFace(hasChildren, parent)
-		if err != nil {
-			return fmt.Errorf("failed to prepare font face: %w", err)
-		}
 		texts := strings.Split(r.label, "\n")
 		for _, line := range texts {
 			textBindings, _ := font.BoundString(fontFace, line)
@@ -419,7 +423,7 @@ func (r *Resource) Scale(parent *Resource, visited map[*Resource]bool) error {
 	}
 
 	for _, subResource := range r.children {
-		err := subResource.Scale(parent, visited)
+		err := subResource.Scale(r, visited)
 		if err != nil {
 			return err
 		}
@@ -511,7 +515,7 @@ func (r *Resource) Scale(parent *Resource, visited map[*Resource]bool) error {
 		if err != nil {
 			return fmt.Errorf("failed to calculate position for border child: %w", err)
 		}
-		err = borderChild.Resource.Scale(parent, visited) // to initialize default values
+		err = borderChild.Resource.Scale(r, visited) // to initialize default values
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR adds Go's embedded goregular font as a fallback option to improve cross-platform compatibility and reduce dependency on system fonts.

## Changes
- Add goregular font option to all platform font paths (Linux, macOS, Windows)
- Implement goregular font loading using golang.org/x/image/font/gofont/goregular
- Fix font inheritance and parent-child relationship in resource scaling
- Add OverrideFontFile option to CreateOptions for testing consistency

## Benefits
- Reduces dependency on system-specific fonts
- Improves cross-platform consistency
- Provides reliable fallback when system fonts are unavailable
- Enables consistent testing across different environments