### PR TITLE
Fix #211: Add overwrite protection with confirmation prompt

### DIFF
--- a/cmd/awsdac-mcp-server/main.go
+++ b/cmd/awsdac-mcp-server/main.go
@@ -264,7 +264,9 @@ func handleGenerateDiagram(
 
 	// Generate diagram directly in the main thread
 	// This ensures logs are properly captured
-	opts := &ctl.CreateOptions{}
+	opts := &ctl.CreateOptions{
+		OverwriteMode: ctl.Force, // Use Force for temporary files
+	}
 	if err := ctl.CreateDiagramFromDacFile(inputFile, &outputFile, opts); err != nil {
 		return nil, fmt.Errorf("failed to create diagram: %v", err)
 	}
@@ -330,7 +332,9 @@ func handleGenerateDiagramToFile(
 	}
 
 	// Generate diagram - save directly to specified path
-	opts := &ctl.CreateOptions{}
+	opts := &ctl.CreateOptions{
+		OverwriteMode: ctl.NoOverwrite, // MCP server refuses to overwrite existing files
+	}
 	if err := ctl.CreateDiagramFromDacFile(inputFile, &outputFilePath, opts); err != nil {
 		return nil, fmt.Errorf("failed to create diagram: %v", err)
 	}

--- a/cmd/awsdac-mcp-server/main_test.go
+++ b/cmd/awsdac-mcp-server/main_test.go
@@ -533,7 +533,7 @@ Diagram:
 		{
 			name:           "invalid output path with null byte",
 			outputPath:     "/tmp/diagram\x00.png",
-			expectedErrMsg: "error opening output file",
+			expectedErrMsg: "failed to check output file",
 		},
 	}
 

--- a/cmd/awsdac/main.go
+++ b/cmd/awsdac/main.go
@@ -22,6 +22,7 @@ func main() {
 	var generateDacFile bool
 	var overrideDefFile string
 	var isGoTemplate bool
+	var force bool
 
 	var rootCmd = &cobra.Command{
 		Use:     "awsdac <input filename>",
@@ -59,6 +60,11 @@ func main() {
 				opts := ctl.CreateOptions{
 					OverrideDefFile: overrideDefFile,
 				}
+				if force {
+					opts.OverwriteMode = ctl.Force
+				} else {
+					opts.OverwriteMode = ctl.Ask
+				}
 				if err := ctl.CreateDiagramFromCFnTemplate(inputFile, &outputFile, generateDacFile, &opts); err != nil {
 					return fmt.Errorf("failed to create diagram from CloudFormation template: %w", err)
 				}
@@ -66,6 +72,11 @@ func main() {
 				opts := ctl.CreateOptions{
 					IsGoTemplate:    isGoTemplate,
 					OverrideDefFile: overrideDefFile,
+				}
+				if force {
+					opts.OverwriteMode = ctl.Force
+				} else {
+					opts.OverwriteMode = ctl.Ask
 				}
 				if err := ctl.CreateDiagramFromDacFile(inputFile, &outputFile, &opts); err != nil {
 					return fmt.Errorf("failed to create diagram: %w", err)
@@ -82,6 +93,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVarP(&generateDacFile, "dac-file", "d", false, "[beta] Generate YAML file in dac (diagram-as-code) format from CloudFormation template")
 	rootCmd.PersistentFlags().StringVarP(&overrideDefFile, "override-def-file", "", "", "For testing purpose, override DefinitionFiles to another url/local file")
 	rootCmd.PersistentFlags().BoolVarP(&isGoTemplate, "template", "t", false, "Processes the input file as a template according to text/template.")
+	rootCmd.PersistentFlags().BoolVarP(&force, "force", "f", false, "Overwrite output file without confirmation")
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/internal/ctl/cfntemplate.go
+++ b/internal/ctl/cfntemplate.go
@@ -130,7 +130,7 @@ func CreateDiagramFromCFnTemplate(inputfile string, outputfile *string, generate
 		go generateDacFileFromCFnTemplate(&template, *outputfile)
 	}
 
-	if err := createDiagram(resources, outputfile); err != nil {
+	if err := createDiagram(resources, outputfile, opts.OverwriteMode); err != nil {
 		return fmt.Errorf("failed to create diagram: %w", err)
 	}
 	return nil

--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -70,18 +70,18 @@ func CheckOutputFileOverwrite(outputFile string, mode OverwriteMode) error {
 // askOverwriteConfirmation shows interactive confirmation prompt
 func askOverwriteConfirmation(outputFile string) error {
 	fmt.Printf("File '%s' already exists. Overwrite? [y/N]: ", outputFile)
-	
+
 	reader := bufio.NewReader(os.Stdin)
 	response, err := reader.ReadString('\n')
 	if err != nil {
 		return fmt.Errorf("failed to read user input: %w", err)
 	}
-	
+
 	response = strings.TrimSpace(strings.ToLower(response))
 	if response == "y" || response == "yes" {
 		return nil
 	}
-	
+
 	return fmt.Errorf("operation cancelled by user")
 }
 

--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -4,6 +4,7 @@
 package ctl
 
 import (
+	"bufio"
 	"fmt"
 	"image"
 	"image/color"
@@ -25,6 +26,63 @@ func stringToColor(c string) (color.RGBA, error) {
 		return color.RGBA{}, fmt.Errorf("failed to parse color string '%s': %w", c, err)
 	}
 	return color.RGBA{r, g, b, a}, nil
+}
+
+// OverwriteMode defines how to handle existing output files
+type OverwriteMode int
+
+const (
+	// Ask shows confirmation prompt when output file exists (CLI default)
+	Ask OverwriteMode = iota
+	// Force overwrites without confirmation (CLI with --force)
+	Force
+	// NoOverwrite refuses to overwrite and returns error (MCP server default)
+	NoOverwrite
+)
+
+// CheckOutputFileOverwrite checks if output file exists and handles according to mode
+func CheckOutputFileOverwrite(outputFile string, mode OverwriteMode) error {
+	// Check if file exists
+	if _, err := os.Stat(outputFile); os.IsNotExist(err) {
+		// File doesn't exist, proceed
+		return nil
+	} else if err != nil {
+		// Some other error occurred
+		return fmt.Errorf("failed to check output file: %w", err)
+	}
+
+	// File exists, handle according to mode
+	switch mode {
+	case Force:
+		// Force mode: proceed without confirmation
+		return nil
+	case NoOverwrite:
+		// NoOverwrite mode: return error
+		return fmt.Errorf("output file '%s' already exists", outputFile)
+	case Ask:
+		// Ask mode: show confirmation prompt
+		return askOverwriteConfirmation(outputFile)
+	default:
+		return fmt.Errorf("unknown overwrite mode: %d", mode)
+	}
+}
+
+// askOverwriteConfirmation shows interactive confirmation prompt
+func askOverwriteConfirmation(outputFile string) error {
+	fmt.Printf("File '%s' already exists. Overwrite? [y/N]: ", outputFile)
+	
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("failed to read user input: %w", err)
+	}
+	
+	response = strings.TrimSpace(strings.ToLower(response))
+	if response == "y" || response == "yes" {
+		return nil
+	}
+	
+	return fmt.Errorf("operation cancelled by user")
 }
 
 type TemplateStruct struct {
@@ -102,9 +160,15 @@ type LinkLabel struct {
 type CreateOptions struct {
 	IsGoTemplate    bool
 	OverrideDefFile string
+	OverwriteMode   OverwriteMode
 }
 
-func createDiagram(resources map[string]*types.Resource, outputfile *string) error {
+func createDiagram(resources map[string]*types.Resource, outputfile *string, overwriteMode OverwriteMode) error {
+
+	// Check for file overwrite before processing
+	if err := CheckOutputFileOverwrite(*outputfile, overwriteMode); err != nil {
+		return err
+	}
 
 	log.Info("--- Draw diagram ---")
 	err := resources["Canvas"].Scale(nil, nil)
@@ -121,7 +185,7 @@ func createDiagram(resources map[string]*types.Resource, outputfile *string) err
 
 	log.Infof("Save %s\n", *outputfile)
 	fmt.Printf("[Completed] AWS infrastructure diagram generated: %s\n", *outputfile)
-	f, err := os.OpenFile(*outputfile, os.O_WRONLY|os.O_CREATE, 0600)
+	f, err := os.OpenFile(*outputfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("error opening output file: %w", err)
 	}

--- a/internal/ctl/dacfile.go
+++ b/internal/ctl/dacfile.go
@@ -151,7 +151,7 @@ func CreateDiagramFromDacFile(inputfile string, outputfile *string, opts *Create
 		return fmt.Errorf("failed to load links: %w", err)
 	}
 
-	if err := createDiagram(resources, outputfile); err != nil {
+	if err := createDiagram(resources, outputfile, opts.OverwriteMode); err != nil {
 		return fmt.Errorf("failed to create diagram: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Summary
This PR fixes issue #211 by adding overwrite protection to prevent accidental loss of previously generated diagrams.

## Changes
- **OverwriteMode enum**: Added `Ask`, `Force`, and `NoOverwrite` modes
- **CLI**: Added confirmation prompt when output file exists
- **CLI**: Added `--force` flag to bypass confirmation  
- **MCP server**: Uses `NoOverwrite` mode to refuse overwriting existing files
- **Core**: Added `CheckOutputFileOverwrite()` function for overwrite handling
- **File handling**: Added `O_TRUNC` flag for proper file overwriting

## Behavior
- **CLI default**: Shows confirmation prompt when file exists
- **CLI with --force**: Overwrites without confirmation
- **MCP server**: Returns error when output file already exists

## Testing
✅ New file creation works normally
✅ Existing file overwrite shows confirmation prompt
✅ User can accept (y) or reject (n) overwrite
✅ --force flag bypasses confirmation
✅ MCP server properly refuses to overwrite existing files

Fixes #211