### PR TITLE
Refactor createDiagram to use CreateOptions struct

### DIFF
--- a/internal/ctl/cfntemplate.go
+++ b/internal/ctl/cfntemplate.go
@@ -130,7 +130,7 @@ func CreateDiagramFromCFnTemplate(inputfile string, outputfile *string, generate
 		go generateDacFileFromCFnTemplate(&template, *outputfile)
 	}
 
-	if err := createDiagram(resources, outputfile, opts.OverwriteMode); err != nil {
+	if err := createDiagram(resources, outputfile, opts); err != nil {
 		return fmt.Errorf("failed to create diagram: %w", err)
 	}
 	return nil

--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -163,10 +163,10 @@ type CreateOptions struct {
 	OverwriteMode   OverwriteMode
 }
 
-func createDiagram(resources map[string]*types.Resource, outputfile *string, overwriteMode OverwriteMode) error {
+func createDiagram(resources map[string]*types.Resource, outputfile *string, opts *CreateOptions) error {
 
 	// Check for file overwrite before processing
-	if err := CheckOutputFileOverwrite(*outputfile, overwriteMode); err != nil {
+	if err := CheckOutputFileOverwrite(*outputfile, opts.OverwriteMode); err != nil {
 		return err
 	}
 

--- a/internal/ctl/dacfile.go
+++ b/internal/ctl/dacfile.go
@@ -151,7 +151,7 @@ func CreateDiagramFromDacFile(inputfile string, outputfile *string, opts *Create
 		return fmt.Errorf("failed to load links: %w", err)
 	}
 
-	if err := createDiagram(resources, outputfile, opts.OverwriteMode); err != nil {
+	if err := createDiagram(resources, outputfile, opts); err != nil {
 		return fmt.Errorf("failed to create diagram: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Changes
- Change createDiagram function signature to accept *CreateOptions instead of OverwriteMode
- Update function calls in cfntemplate.go and dacfile.go to pass opts instead of opts.OverwriteMode
- Prepare for future option additions with flexible options structure

## Testing
- Verified both awsdac and awsdac-mcp-server build successfully
- Confirmed force option works correctly (prompts without --force, overwrites with --force)