### PR TITLE
Fix swapped descriptions of Direction and Align

### DIFF
--- a/doc/resource-types.md
+++ b/doc/resource-types.md
@@ -39,9 +39,9 @@ An essential resource type that represents a single resource or group. The follo
 | -------------- | ------------- | ------------------------------------------ | ----------------------------------------------------------------------- |
 | Icon           | string        | ` `                                        | Icon file path                                                          |
 | IconFill       | IconFill      | `Type: none, Color: rgba(255,255,255,255)` | Filling icon background                                                 |
-| Direction      | string        | `horizontal`                               | vertical: `left`,`center`,`right` horizontal: `top`, `center`, `bottom` |
+| Direction      | string        | `horizontal`                               | `vertical`, `horizontal`                                                |
 | Preset         | string        | ` `                                        | Override resource attributes from preset                                |
-| Align          | string        | `center`                                   | `vertical`, `horizontal`                                                |
+| Align          | string        | `center`                                   | vertical: `left`,`center`,`right` horizontal: `top`, `center`, `bottom` |
 | FillColor      | string        | `rgba(0,0,0,0)`                            | Only group.                                                             |
 | BorderColor    | string        | `rgba(0,0,0,0)`                            |                                                                         |
 | Title          | string        | ` `                                        |                                                                         |


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Fix swapped descriptions of **Direction** and **Align** in the table of `doc/resource-types.md`.

- **Direction** should specify the stacking axis: `vertical` or `horizontal`.
- **Align** should specify cross-axis alignment:
  - `vertical`:  `left`, `center`, or `right`
  - `horizontal`:  `top`, `center`, or `bottom`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
