### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -11,6 +11,8 @@ name: Unit test
 jobs:
   build:
     name: Test
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     defaults:
       run:


### PR DESCRIPTION
Potential fix for [https://github.com/awslabs/diagram-as-code/security/code-scanning/8](https://github.com/awslabs/diagram-as-code/security/code-scanning/8)

The fix is to add an explicit `permissions:` block to the workflow or to the affected `build` job. In this case, because the workflow only has one job, and the job does not require any elevated permissions, it's best to add `permissions: contents: read` at the job level (just under `build:`) OR at the workflow level (just after the `name:` at line 9/10). This ensures the permissions for the GitHub Actions `GITHUB_TOKEN` are set to read-only for contents, preventing any accidental write access and adhering to the principle of least privilege. No imports or other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
