### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
 
 name: Create release from tag
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -58,6 +61,8 @@ jobs:
     name: Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Potential fix for [https://github.com/awslabs/diagram-as-code/security/code-scanning/7](https://github.com/awslabs/diagram-as-code/security/code-scanning/7)

To fix this issue, add an explicit `permissions` block at the root of the workflow (above the `jobs:` key) that sets the minimal base permissions, typically `contents: read`, for all jobs. Then, in the jobs that require increased permissions (such as the `release` job, which uses GitHub CLI, likely requiring `contents: write` to create releases and upload assets), add a specific `permissions` block in that job with the required elevated access: `contents: write`. This follows least privilege principles and makes the workflow's intentions explicit. Only the `.github/workflows/release.yml` file should be changed, and the change should insert the relevant `permissions` keys and YAML blocks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
