### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wiki_sync.yaml
+++ b/.github/workflows/wiki_sync.yaml
@@ -1,5 +1,8 @@
 name: sync wiki
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: main


### PR DESCRIPTION
Potential fix for [https://github.com/awslabs/diagram-as-code/security/code-scanning/5](https://github.com/awslabs/diagram-as-code/security/code-scanning/5)

To fix the problem, we should explicitly specify required GitHub token permissions for the workflow. Since the workflow performs pushes to the wiki, which is a special repo under the main project, it requires `contents: write`. This can be set at the workflow level (just under the `name` and optionally `on:` keys) or at the individual job level. The simplest and most effective solution here is to add a `permissions` block at the workflow root, directly after the `name` (or `on:`) key, specifying `contents: write`. 

**Where to change:**  
- In `.github/workflows/wiki_sync.yaml`, insert the following block after the `name: sync wiki` line (and before or after the `on` block; per YAML, it's fine after `on` for readability), like this:
  ```yaml
  permissions:
    contents: write
  ```

No imports, method, or other code changes are necessary, just this YAML addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
