### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fmt-check.yml
+++ b/.github/workflows/fmt-check.yml
@@ -1,5 +1,8 @@
 name: Go Format Check
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ '**' ]


### PR DESCRIPTION
Potential fix for [https://github.com/awslabs/diagram-as-code/security/code-scanning/3](https://github.com/awslabs/diagram-as-code/security/code-scanning/3)

To fix the problem, you should add a `permissions` block specifying the least permissions required for this workflow. Since the job only analyzes source code and does not need to modify repository contents or perform privileged operations, the best option is to grant `contents: read` at either the workflow root or inside the `format-check` job. Adding it to the workflow root will apply to all jobs, but if you want to be even more scoped, you can add it just below the `jobs.format-check` definition. Edit the `.github/workflows/fmt-check.yml` file and insert a `permissions: contents: read` line appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
