### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/func_test.yaml
+++ b/.github/workflows/func_test.yaml
@@ -7,6 +7,8 @@ on:
       - main
 
 name: Functional test
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/awslabs/diagram-as-code/security/code-scanning/2](https://github.com/awslabs/diagram-as-code/security/code-scanning/2)

The best way to fix this issue is to add an explicit `permissions` block to the workflow or to the specific job(s) defined. Because this workflow only needs to read repository contents, we can restrict `GITHUB_TOKEN` permissions to `contents: read` at the job level (within the `build` job) or, more simply, at the root of the workflow so all jobs are restricted accordingly. In this case, adding:
```yaml
permissions:
  contents: read
```
at the top level (after `name: Functional test` and before `jobs:`) is the preferred fix. This change does not alter any existing functionality; it only restricts the permissions granted to the workflow. No additional imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
