### PR TITLE
Enable func_test and unit_test workflows on all branches

### DIFF
--- a/.github/workflows/func_test.yaml
+++ b/.github/workflows/func_test.yaml
@@ -1,10 +1,18 @@
 on:
   push:
-    branches:
-      - main
+    branches: [ '**' ]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/func_test.yaml'
   pull_request:
-    branches:
-      - main
+    branches: [ '**' ]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+  workflow_dispatch:
 
 name: Functional test
 permissions:

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -1,10 +1,18 @@
 on:
   push:
-    branches:
-      - main
+    branches: [ '**' ]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/unit_test.yaml'
   pull_request:
-    branches:
-      - main
+    branches: [ '**' ]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+  workflow_dispatch:
 
 name: Unit test
 


### PR DESCRIPTION
This PR enables func_test and unit_test workflows to run on all branches (not just main), making them consistent with the fmt-check workflow.

Changes:
- Updated trigger conditions in func_test.yaml and unit_test.yaml to use branches: ['**']
- Added path filters to run only when Go files, go.mod, go.sum, or workflow files change
- Added workflow_dispatch for manual execution

This allows the workflows to run on forked repositories when pushing to any branch.