### PR TITLE
fix: font fallback handling

### DIFF
--- a/internal/types/link.go
+++ b/internal/types/link.go
@@ -158,7 +158,7 @@ func (l *Link) prepareFontFace(label *LinkLabel, parent1, parent2 *Resource) (fo
 		}
 	}
 	var ttfBytes []byte
-	if label.Font == "goregular" {
+	if label.Font == "goregular" || label.Font == "" {
 		// Use Go-fonts instead system fonts
 		ttfBytes = goregular.TTF
 	} else {

--- a/internal/types/resource.go
+++ b/internal/types/resource.go
@@ -272,7 +272,7 @@ func (r *Resource) prepareFontFace(hasChild bool, parent *Resource) (font.Face, 
 		}
 	}
 	var ttfBytes []byte
-	if r.labelFont == "goregular" {
+	if r.labelFont == "goregular" || r.labelFont == "" {
 		// Use Go-fonts instead system fonts
 		ttfBytes = goregular.TTF
 	} else {


### PR DESCRIPTION
*Issue #, if available:*
- The *goregular* font is embedded for environment where [the specified fonts](https://github.com/awslabs/diagram-as-code/blob/main/internal/font/linux.go) are not available (mainly Linux), but this font is not used unless you explicitly specified the font.
```
Error: failed to create diagram: failed to create diagram: error scaling diagram: failed to prepare font face: failed to open font file: open : no such file or directory
```

*Description of changes:*
- Fallback to embedded *goregular* font if no font is specified explicitly

