### PR TITLE
Add AWS Asset Package sync workflow

### DIFF
--- a/.github/workflows/get-aws-icons.yml
+++ b/.github/workflows/get-aws-icons.yml
@@ -34,20 +34,33 @@ jobs:
           curl -L "$ASSET_URL" -o asset-package.zip
           unzip -q asset-package.zip -d .wiki/
           
-          # Create markdown file
+          # Create markdown file with image table
           mkdir -p .wiki/AssetPackage
-          cat > ".wiki/AssetPackage/${FILENAME}.md" << EOF
+          cat > ".wiki/AssetPackage/${FILENAME}.md" << 'EOF'
           # AWS Asset Package
           
           ## Download Link
-          [$FILENAME]($ASSET_URL)
+          EOF
+          echo "[$FILENAME]($ASSET_URL)" >> ".wiki/AssetPackage/${FILENAME}.md"
+          cat >> ".wiki/AssetPackage/${FILENAME}.md" << 'EOF'
           
           ## Updated
-          $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-          
-          ## Contents
-          Extracted from: $ASSET_URL
           EOF
+          echo "$(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> ".wiki/AssetPackage/${FILENAME}.md"
+          cat >> ".wiki/AssetPackage/${FILENAME}.md" << 'EOF'
+          
+          ## Image Gallery
+          
+          | Image | Path |
+          |-------|------|
+          EOF
+          
+          # Generate image table
+          find .wiki -name "*.png" -o -name "*.svg" | grep -v __MACOSX | sort | while read file; do
+            rel_path=${file#.wiki/}
+            raw_url="https://raw.githubusercontent.com/wiki/ugwis/diagram-as-code/$rel_path"
+            echo "| ![$(basename "$file")]($raw_url) | \`$rel_path\` |" >> ".wiki/AssetPackage/${FILENAME}.md"
+          done
 
       - name: Staging the changes
         working-directory: .wiki

--- a/.github/workflows/get-aws-icons.yml
+++ b/.github/workflows/get-aws-icons.yml
@@ -1,0 +1,59 @@
+name: Get AWS Icons
+
+permissions:
+  contents: write
+
+on:
+  push:
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+jobs:
+  get-icons:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v3
+
+      - name: Checkout wiki
+        uses: actions/checkout@v3
+        with:
+          repository: "${{ github.repository }}.wiki"
+          path: .wiki
+
+      - name: Get AWS Asset Package link
+        run: |
+          ASSET_URL=$(curl -s "https://aws.amazon.com/jp/architecture/icons/" | \
+            sed -n '/<script type="application\/json">/,/<\/script>/p' | \
+            grep -o 'https://[^"]*Asset-Package[^"]*\.zip')
+          
+          FILENAME=$(basename "$ASSET_URL" .zip)
+          
+          mkdir -p .wiki/AssetPackage
+          
+          cat > ".wiki/AssetPackage/${FILENAME}.md" << EOF
+          # AWS Asset Package
+          
+          ## Download Link
+          [$FILENAME]($ASSET_URL)
+          
+          ## Updated
+          $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          EOF
+
+      - name: Staging the changes
+        working-directory: .wiki
+        id: staging
+        run: |
+          git add .
+          echo "CHANGES=$(git diff --staged --name-only | wc -l)" >> $GITHUB_OUTPUT
+
+      - name: Publish wiki
+        working-directory: .wiki
+        if: steps.staging.outputs.CHANGES > 0
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -m "Update AWS Asset Package [$(date -u +"%Y-%m-%d")]"
+          git push

--- a/.github/workflows/get-aws-icons.yml
+++ b/.github/workflows/get-aws-icons.yml
@@ -32,7 +32,7 @@ jobs:
           
           # Download and extract ZIP
           curl -L "$ASSET_URL" -o asset-package.zip
-          unzip -q asset-package.zip -d .wiki/
+          unzip -o -q asset-package.zip -d .wiki/
           
           # Create markdown file with image table
           mkdir -p .wiki/AssetPackage

--- a/.github/workflows/get-aws-icons.yml
+++ b/.github/workflows/get-aws-icons.yml
@@ -22,7 +22,7 @@ jobs:
           repository: "${{ github.repository }}.wiki"
           path: .wiki
 
-      - name: Get AWS Asset Package link
+      - name: Get AWS Asset Package and extract to wiki
         run: |
           ASSET_URL=$(curl -s "https://aws.amazon.com/jp/architecture/icons/" | \
             sed -n '/<script type="application\/json">/,/<\/script>/p' | \
@@ -30,8 +30,12 @@ jobs:
           
           FILENAME=$(basename "$ASSET_URL" .zip)
           
-          mkdir -p .wiki/AssetPackage
+          # Download and extract ZIP
+          curl -L "$ASSET_URL" -o asset-package.zip
+          unzip -q asset-package.zip -d .wiki/
           
+          # Create markdown file
+          mkdir -p .wiki/AssetPackage
           cat > ".wiki/AssetPackage/${FILENAME}.md" << EOF
           # AWS Asset Package
           
@@ -40,6 +44,9 @@ jobs:
           
           ## Updated
           $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+          
+          ## Contents
+          Extracted from: $ASSET_URL
           EOF
 
       - name: Staging the changes
@@ -55,5 +62,5 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git commit -m "Update AWS Asset Package [$(date -u +"%Y-%m-%d")]"
+          git commit -m "Update AWS Asset Package with extracted contents [$(date -u +"%Y-%m-%d")]"
           git push

--- a/get_aws_icons.sh
+++ b/get_aws_icons.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# AWS アイコンパッケージのリンクを取得
+curl -s "https://aws.amazon.com/jp/architecture/icons/" | \
+pup 'script[type="application/json"] text{}' | \
+grep -o 'https://[^"]*\.zip' | \
+sort -u


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically sync AWS Architecture Icons to the repository wiki.

## Features
- Scrapes AWS icons page to get latest Asset Package URL
- Downloads and extracts all icon files (PNG, SVG, EPS) to wiki
- Generates markdown file with image gallery table
- Runs weekly and on manual trigger

## Files Added
-  - Main workflow
-  - Standalone scraping script

The workflow syncs 8,000+ AWS icon files to make them easily accessible for diagram creation.