### PR TITLE
Fix orthogonal link detour issue (#236)

### DIFF
--- a/internal/types/link.go
+++ b/internal/types/link.go
@@ -560,6 +560,15 @@ func (l *Link) calculateOrthogonalPath(sourcePt, targetPt image.Point) []image.P
 							// Normal parallel: share distance
 							moveDistance = math.Abs(remaining.X) / 2.0
 						}
+					} else {
+						// Non-parallel case: account for counterpart detour
+						if targetPenetration {
+							detourDistance := 64.0/2 + 20  // 52px
+							moveDistance = math.Abs(remaining.X) - detourDistance
+							if moveDistance < 0 {
+								moveDistance = 20.0
+							}
+						}
 					}
 				} else {
 					moveDistance = math.Abs(remaining.Y)
@@ -572,6 +581,15 @@ func (l *Link) calculateOrthogonalPath(sourcePt, targetPt image.Point) []image.P
 						} else {
 							// Normal parallel: share distance
 							moveDistance = math.Abs(remaining.Y) / 2.0
+						}
+					} else {
+						// Non-parallel case: account for counterpart detour
+						if targetPenetration {
+							detourDistance := 64.0/2 + 20  // 52px
+							moveDistance = math.Abs(remaining.Y) - detourDistance
+							if moveDistance < 0 {
+								moveDistance = 20.0
+							}
 						}
 					}
 				}
@@ -671,6 +689,15 @@ func (l *Link) calculateOrthogonalPath(sourcePt, targetPt image.Point) []image.P
 							// Normal parallel: share distance
 							moveDistance = math.Abs(remaining.X) / 2.0
 						}
+					} else {
+						// Non-parallel case: account for counterpart detour
+						if sourcePenetration {
+							detourDistance := 64.0/2 + 20  // 52px
+							moveDistance = math.Abs(remaining.X) - detourDistance
+							if moveDistance < 0 {
+								moveDistance = 20.0
+							}
+						}
 					}
 				} else {
 					moveDistance = math.Abs(remaining.Y)
@@ -683,6 +710,15 @@ func (l *Link) calculateOrthogonalPath(sourcePt, targetPt image.Point) []image.P
 						} else {
 							// Normal parallel: share distance
 							moveDistance = math.Abs(remaining.Y) / 2.0
+						}
+					} else {
+						// Non-parallel case: account for counterpart detour
+						if sourcePenetration {
+							detourDistance := 64.0/2 + 20  // 52px
+							moveDistance = math.Abs(remaining.Y) - detourDistance
+							if moveDistance < 0 {
+								moveDistance = 20.0
+							}
 						}
 					}
 				}


### PR DESCRIPTION
## Summary
Fixes #236 - Orthogonal link improvement: wrong control points with detour

## Problem
The orthogonal link routing was generating incorrect control points, creating unnecessary detours in the path:
- **Before**: `[(626,856) (646,856) (646,804) (646,804) (646,856) (402,856) (402,607)]`
- **After**: `[(626,856) (646,856) (646,804) (402,804) (402,607)]`

## Root Cause
In non-parallel cases, when one resource has penetration and the other doesn't, the non-penetrating resource was not accounting for the counterpart's detour distance, leading to inefficient path calculation.

## Solution
- Added counterpart detour consideration for non-parallel cases in Step 0 movement calculation
- When `sourcePenetration && !targetPenetration`: Target reduces movement by detour distance (52px)
- When `!sourcePenetration && targetPenetration`: Source reduces movement by detour distance (52px)
- Applied to both X-axis and Y-axis movements

## Results
- Reduced control points from 5 to 3 for efficient routing
- Eliminated unnecessary backtracking
- Fixed duplicate control points issue
- Maintains proper orthogonal path behavior

## Testing
Tested with the original issue's YAML configuration:
- SSH link from Administrator (E position) to EC2A (S position)
- Verified correct path generation without detours