### PR TITLE
feat: add link grouping offset to prevent overlapping links #252

### DIFF
--- a/doc/links.md
+++ b/doc/links.md
@@ -141,7 +141,7 @@ Resources:
   ELB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Options:
-      EnableGroupingOffset: true  # Enable link grouping offset
+      GroupingOffset: true  # Enable link grouping offset
 ```
 
 **Example with multiple links:**
@@ -150,7 +150,7 @@ Resources:
   ELB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Options:
-      EnableGroupingOffset: true
+      GroupingOffset: true
       
 Links:
   - Source: ELB

--- a/doc/links.md
+++ b/doc/links.md
@@ -125,4 +125,35 @@ Link Labels add labels along the link
           Font: (optional, default: `` inherit from Source,Target font name)
 ```
 
+### Link Grouping Offset
+
+When multiple links originate from the same position, they are automatically spread apart to prevent overlap.
+
+**Automatic behavior:**
+- Links from the same position are offset by ±5px, ±10px, etc.
+- Links are sorted by target position to prevent crossing
+- Offset is applied perpendicular to the link direction
+
+**Example:**
+```yaml
+Links:
+  - Source: ELB
+    Target: Instance1
+    SourcePosition: S  # Multiple links from same position
+    TargetPosition: N
+  - Source: ELB
+    Target: Instance2
+    SourcePosition: S  # Will be automatically offset
+    TargetPosition: N
+```
+
+**Disable for specific resource:**
+```yaml
+Resources:
+  ELB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Options:
+      DisableGroupingOffset: true  # Links will overlap
+```
+
 

--- a/doc/links.md
+++ b/doc/links.md
@@ -127,15 +127,31 @@ Link Labels add labels along the link
 
 ### Link Grouping Offset
 
-When multiple links originate from the same position, they are automatically spread apart to prevent overlap.
+When multiple links originate from or terminate at the same position on a resource, they can be automatically spread apart to prevent overlap. This feature is **disabled by default** and must be explicitly enabled.
 
-**Automatic behavior:**
+**How it works:**
 - Links from the same position are offset by ±5px, ±10px, etc.
-- Links are sorted by target position to prevent crossing
+- Links are sorted by target/source position for consistent ordering
 - Offset is applied perpendicular to the link direction
+- Calculation: `(index - (count-1)/2.0) * 10` pixels
 
-**Example:**
+**Enable for specific resource:**
 ```yaml
+Resources:
+  ELB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Options:
+      EnableGroupingOffset: true  # Enable link grouping offset
+```
+
+**Example with multiple links:**
+```yaml
+Resources:
+  ELB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Options:
+      EnableGroupingOffset: true
+      
 Links:
   - Source: ELB
     Target: Instance1
@@ -145,15 +161,12 @@ Links:
     Target: Instance2
     SourcePosition: S  # Will be automatically offset
     TargetPosition: N
+  - Source: ELB
+    Target: Instance3
+    SourcePosition: S  # Will be automatically offset
+    TargetPosition: N
 ```
 
-**Disable for specific resource:**
-```yaml
-Resources:
-  ELB:
-    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
-    Options:
-      DisableGroupingOffset: true  # Links will overlap
-```
+**Result:** Links will be spread horizontally (perpendicular to S direction) to prevent overlap.
 
 

--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -123,7 +123,7 @@ type Resource struct {
 }
 
 type ResourceOptions struct {
-	EnableGroupingOffset *bool `yaml:"EnableGroupingOffset"`
+	GroupingOffset *bool `yaml:"GroupingOffset"`
 }
 
 type ResourceIconFill struct {
@@ -600,8 +600,8 @@ func loadResources(template *TemplateStruct, ds definition.DefinitionStructure, 
 			if !exists {
 				return fmt.Errorf("resource %s not found for options", k)
 			}
-			if v.Options.EnableGroupingOffset != nil {
-				resource.SetEnableGroupingOffset(*v.Options.EnableGroupingOffset)
+			if v.Options.GroupingOffset != nil {
+				resource.SetEnableGroupingOffset(*v.Options.GroupingOffset)
 			}
 		}
 	}

--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -593,7 +593,7 @@ func loadResources(template *TemplateStruct, ds definition.DefinitionStructure, 
 			}
 			resource.SetBorderColor(borderColor)
 		}
-		
+
 		// Process Options
 		if v.Options != nil {
 			resource, exists := resources[k]

--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -123,7 +123,7 @@ type Resource struct {
 }
 
 type ResourceOptions struct {
-	DisableGroupingOffset *bool `yaml:"DisableGroupingOffset"`
+	EnableGroupingOffset *bool `yaml:"EnableGroupingOffset"`
 }
 
 type ResourceIconFill struct {
@@ -600,8 +600,8 @@ func loadResources(template *TemplateStruct, ds definition.DefinitionStructure, 
 			if !exists {
 				return fmt.Errorf("resource %s not found for options", k)
 			}
-			if v.Options.DisableGroupingOffset != nil {
-				resource.SetDisableGroupingOffset(*v.Options.DisableGroupingOffset)
+			if v.Options.EnableGroupingOffset != nil {
+				resource.SetEnableGroupingOffset(*v.Options.EnableGroupingOffset)
 			}
 		}
 	}

--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -119,6 +119,11 @@ type Resource struct {
 	Children       []string          `yaml:"Children"`
 	BorderColor    string            `yaml:"BorderColor"`
 	BorderChildren []BorderChild     `yaml:"BorderChildren"`
+	Options        *ResourceOptions  `yaml:"Options"`
+}
+
+type ResourceOptions struct {
+	DisableGroupingOffset *bool `yaml:"DisableGroupingOffset"`
 }
 
 type ResourceIconFill struct {
@@ -587,6 +592,17 @@ func loadResources(template *TemplateStruct, ds definition.DefinitionStructure, 
 				return fmt.Errorf("resource %s not found for border color", k)
 			}
 			resource.SetBorderColor(borderColor)
+		}
+		
+		// Process Options
+		if v.Options != nil {
+			resource, exists := resources[k]
+			if !exists {
+				return fmt.Errorf("resource %s not found for options", k)
+			}
+			if v.Options.DisableGroupingOffset != nil {
+				resource.SetDisableGroupingOffset(*v.Options.DisableGroupingOffset)
+			}
 		}
 	}
 

--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -601,7 +601,7 @@ func loadResources(template *TemplateStruct, ds definition.DefinitionStructure, 
 				return fmt.Errorf("resource %s not found for options", k)
 			}
 			if v.Options.GroupingOffset != nil {
-				resource.SetEnableGroupingOffset(*v.Options.GroupingOffset)
+				resource.SetGroupingOffset(*v.Options.GroupingOffset)
 			}
 		}
 	}

--- a/internal/types/link.go
+++ b/internal/types/link.go
@@ -831,7 +831,7 @@ func (l *Link) calcPositionWithOffset(bindings image.Rectangle, position Windros
 		return pt
 	}
 
-	// 同じ位置から出るリンク数とインデックスを取得
+	// Get link count and index from the same position
 	index, count := l.getLinkIndexAndCount(resource, position, isSource)
 	log.Infof("Link offset calculation - Resource: %p, Position: %v, IsSource: %v, Index: %d, Count: %d",
 		resource, position, isSource, index, count)
@@ -841,11 +841,11 @@ func (l *Link) calcPositionWithOffset(bindings image.Rectangle, position Windros
 		return pt
 	}
 
-	// オフセット計算: 中央を基準に左右に振り分け
+	// Offset calculation: distribute left and right from center
 	groupingOffset := int((float64(index) - float64(count-1)/2.0) * 10)
 	log.Infof("Calculated grouping offset: %d (index=%d, count=%d)", groupingOffset, index, count)
 
-	// 方向ベクトルの直交方向にオフセット
+	// Apply offset in perpendicular direction to direction vector
 	direction := l.getDirectionVector(int(position))
 	perpendicular := direction.Perpendicular()
 	offset := perpendicular.Scale(float64(groupingOffset))

--- a/internal/types/link.go
+++ b/internal/types/link.go
@@ -826,7 +826,7 @@ func (l *Link) calcPositionWithOffset(bindings image.Rectangle, position Windros
 	pt, _ := calcPosition(bindings, position)
 
 	// Check if grouping offset is enabled for this resource
-	if !resource.enableGroupingOffset {
+	if !resource.groupingOffset {
 		log.Infof("Grouping offset disabled for resource %p, using original position: (%d, %d)", resource, pt.X, pt.Y)
 		return pt
 	}

--- a/internal/types/link.go
+++ b/internal/types/link.go
@@ -824,47 +824,47 @@ func (l *Link) calculateOrthogonalPath(sourcePt, targetPt image.Point) []image.P
 
 func (l *Link) calcPositionWithOffset(bindings image.Rectangle, position Windrose, resource *Resource, isSource bool) image.Point {
 	pt, _ := calcPosition(bindings, position)
-	
+
 	// Check if grouping offset is disabled for this resource
 	if resource.disableGroupingOffset {
 		log.Infof("Grouping offset disabled for resource %p, using original position: (%d, %d)", resource, pt.X, pt.Y)
 		return pt
 	}
-	
+
 	// 同じ位置から出るリンク数とインデックスを取得
 	index, count := l.getLinkIndexAndCount(resource, position, isSource)
-	log.Infof("Link offset calculation - Resource: %p, Position: %v, IsSource: %v, Index: %d, Count: %d", 
+	log.Infof("Link offset calculation - Resource: %p, Position: %v, IsSource: %v, Index: %d, Count: %d",
 		resource, position, isSource, index, count)
-	
+
 	if count <= 1 {
 		log.Infof("Single link, no offset needed - Position: (%d, %d)", pt.X, pt.Y)
 		return pt
 	}
-	
+
 	// オフセット計算: 中央を基準に左右に振り分け
 	groupingOffset := int((float64(index) - float64(count-1)/2.0) * 10)
 	log.Infof("Calculated grouping offset: %d (index=%d, count=%d)", groupingOffset, index, count)
-	
+
 	// 方向ベクトルの直交方向にオフセット
 	direction := l.getDirectionVector(int(position))
 	perpendicular := direction.Perpendicular()
 	offset := perpendicular.Scale(float64(groupingOffset))
-	
+
 	finalPt := image.Point{
 		X: pt.X + int(math.Round(offset.X)),
 		Y: pt.Y + int(math.Round(offset.Y)),
 	}
-	
-	log.Infof("Position offset applied - Original: (%d, %d), Direction: %v, Perpendicular: %v, Final: (%d, %d)", 
+
+	log.Infof("Position offset applied - Original: (%d, %d), Direction: %v, Perpendicular: %v, Final: (%d, %d)",
 		pt.X, pt.Y, direction, perpendicular, finalPt.X, finalPt.Y)
-	
+
 	return finalPt
 }
 
 func (l *Link) getLinkIndexAndCount(resource *Resource, position Windrose, isSource bool) (int, int) {
 	index := 0
 	count := 0
-	
+
 	for _, link := range resource.links {
 		var linkPosition Windrose
 		if isSource && link.Source == resource {
@@ -874,7 +874,7 @@ func (l *Link) getLinkIndexAndCount(resource *Resource, position Windrose, isSou
 		} else {
 			continue
 		}
-		
+
 		if linkPosition == position {
 			if link == l {
 				index = count

--- a/internal/types/link.go
+++ b/internal/types/link.go
@@ -825,8 +825,8 @@ func (l *Link) calculateOrthogonalPath(sourcePt, targetPt image.Point) []image.P
 func (l *Link) calcPositionWithOffset(bindings image.Rectangle, position Windrose, resource *Resource, isSource bool) image.Point {
 	pt, _ := calcPosition(bindings, position)
 
-	// Check if grouping offset is disabled for this resource
-	if resource.disableGroupingOffset {
+	// Check if grouping offset is enabled for this resource
+	if !resource.enableGroupingOffset {
 		log.Infof("Grouping offset disabled for resource %p, using original position: (%d, %d)", resource, pt.X, pt.Y)
 		return pt
 	}

--- a/internal/types/link.go
+++ b/internal/types/link.go
@@ -355,8 +355,8 @@ func (l *Link) Draw(img *image.RGBA) error {
 		return nil
 	}
 	log.Info("Link Drawing")
-	sourcePt, _ := calcPosition(source.GetBindings(), l.SourcePosition)
-	targetPt, _ := calcPosition(target.GetBindings(), l.TargetPosition)
+	sourcePt := l.calcPositionWithOffset(source.GetBindings(), l.SourcePosition, l.Source, true)
+	targetPt := l.calcPositionWithOffset(target.GetBindings(), l.TargetPosition, l.Target, false)
 
 	if l.Type == "" || l.Type == "straight" {
 		l.drawLine(img, sourcePt, targetPt)
@@ -820,6 +820,70 @@ func (l *Link) calculateOrthogonalPath(sourcePt, targetPt image.Point) []image.P
 	log.Infof("Final control points: %v", controlPts)
 	log.Infof("=== End Convergent Calculation ===")
 	return controlPts
+}
+
+func (l *Link) calcPositionWithOffset(bindings image.Rectangle, position Windrose, resource *Resource, isSource bool) image.Point {
+	pt, _ := calcPosition(bindings, position)
+	
+	// Check if grouping offset is disabled for this resource
+	if resource.disableGroupingOffset {
+		log.Infof("Grouping offset disabled for resource %p, using original position: (%d, %d)", resource, pt.X, pt.Y)
+		return pt
+	}
+	
+	// 同じ位置から出るリンク数とインデックスを取得
+	index, count := l.getLinkIndexAndCount(resource, position, isSource)
+	log.Infof("Link offset calculation - Resource: %p, Position: %v, IsSource: %v, Index: %d, Count: %d", 
+		resource, position, isSource, index, count)
+	
+	if count <= 1 {
+		log.Infof("Single link, no offset needed - Position: (%d, %d)", pt.X, pt.Y)
+		return pt
+	}
+	
+	// オフセット計算: 中央を基準に左右に振り分け
+	groupingOffset := int((float64(index) - float64(count-1)/2.0) * 10)
+	log.Infof("Calculated grouping offset: %d (index=%d, count=%d)", groupingOffset, index, count)
+	
+	// 方向ベクトルの直交方向にオフセット
+	direction := l.getDirectionVector(int(position))
+	perpendicular := direction.Perpendicular()
+	offset := perpendicular.Scale(float64(groupingOffset))
+	
+	finalPt := image.Point{
+		X: pt.X + int(math.Round(offset.X)),
+		Y: pt.Y + int(math.Round(offset.Y)),
+	}
+	
+	log.Infof("Position offset applied - Original: (%d, %d), Direction: %v, Perpendicular: %v, Final: (%d, %d)", 
+		pt.X, pt.Y, direction, perpendicular, finalPt.X, finalPt.Y)
+	
+	return finalPt
+}
+
+func (l *Link) getLinkIndexAndCount(resource *Resource, position Windrose, isSource bool) (int, int) {
+	index := 0
+	count := 0
+	
+	for _, link := range resource.links {
+		var linkPosition Windrose
+		if isSource && link.Source == resource {
+			linkPosition = link.SourcePosition
+		} else if !isSource && link.Target == resource {
+			linkPosition = link.TargetPosition
+		} else {
+			continue
+		}
+		
+		if linkPosition == position {
+			if link == l {
+				index = count
+				log.Infof("Found current link at sorted index %d for position %v", index, position)
+			}
+			count++
+		}
+	}
+	return index, count
 }
 
 // getDirectionVector converts windrose position to unit direction vector

--- a/internal/types/link_test.go
+++ b/internal/types/link_test.go
@@ -1875,3 +1875,120 @@ func TestCounterpartDetourConsideration(t *testing.T) {
 	t.Logf("Target converged at Y=%d (expected %d)", targetConvergeY, expectedTargetY)
 	t.Log("=== End Counterpart Detour Test ===")
 }
+
+func TestGroupingOffset(t *testing.T) {
+	// Setup resources
+	source := new(Resource).Init()
+	source.SetBindings(image.Rect(0, 0, 64, 64))
+	
+	target1 := new(Resource).Init()
+	target1.SetBindings(image.Rect(100, 0, 164, 64))
+	
+	target2 := new(Resource).Init()
+	target2.SetBindings(image.Rect(200, 0, 264, 64))
+	
+	// Create links from same source position
+	link1 := new(Link).Init(source, WINDROSE_S, ArrowHead{}, target1, WINDROSE_N, ArrowHead{}, 2, color.RGBA{0, 0, 0, 255})
+	link2 := new(Link).Init(source, WINDROSE_S, ArrowHead{}, target2, WINDROSE_N, ArrowHead{}, 2, color.RGBA{0, 0, 0, 255})
+	
+	source.AddLink(link1)
+	source.AddLink(link2)
+	target1.AddLink(link1)
+	target2.AddLink(link2)
+	
+	// Test normal grouping offset
+	t.Run("Normal grouping offset", func(t *testing.T) {
+		// Sort links first
+		source.sortAllLinks()
+		
+		// Test first link offset
+		index1, count1 := link1.getLinkIndexAndCount(source, WINDROSE_S, true)
+		if count1 != 2 {
+			t.Errorf("Expected count 2, got %d", count1)
+		}
+		
+		// Calculate expected offset: (index - (count-1)/2.0) * 10
+		expectedOffset1 := int((float64(index1) - float64(count1-1)/2.0) * 10)
+		
+		pt1 := link1.calcPositionWithOffset(source.GetBindings(), WINDROSE_S, source, true)
+		originalPt, _ := calcPosition(source.GetBindings(), WINDROSE_S)
+		
+		// Check if offset was applied
+		if pt1.X == originalPt.X && pt1.Y == originalPt.Y && expectedOffset1 != 0 {
+			t.Errorf("Expected offset to be applied, but position unchanged")
+		}
+	})
+	
+	// Test disabled grouping offset
+	t.Run("Disabled grouping offset", func(t *testing.T) {
+		source.SetDisableGroupingOffset(true)
+		
+		pt1 := link1.calcPositionWithOffset(source.GetBindings(), WINDROSE_S, source, true)
+		originalPt, _ := calcPosition(source.GetBindings(), WINDROSE_S)
+		
+		// Should use original position when disabled
+		if pt1.X != originalPt.X || pt1.Y != originalPt.Y {
+			t.Errorf("Expected original position (%d, %d), got (%d, %d)", 
+				originalPt.X, originalPt.Y, pt1.X, pt1.Y)
+		}
+	})
+}
+
+func TestLinkSorting(t *testing.T) {
+	// Setup resources with different X positions
+	source := new(Resource).Init()
+	source.SetBindings(image.Rect(100, 0, 164, 64))
+	
+	target1 := new(Resource).Init()
+	target1.SetBindings(image.Rect(0, 100, 64, 164))    // Left target
+	
+	target2 := new(Resource).Init()
+	target2.SetBindings(image.Rect(200, 100, 264, 164)) // Right target
+	
+	// Create links
+	link1 := new(Link).Init(source, WINDROSE_S, ArrowHead{}, target1, WINDROSE_N, ArrowHead{}, 2, color.RGBA{0, 0, 0, 255})
+	link2 := new(Link).Init(source, WINDROSE_S, ArrowHead{}, target2, WINDROSE_N, ArrowHead{}, 2, color.RGBA{0, 0, 0, 255})
+	
+	// Add in reverse order to test sorting
+	source.AddLink(link2) // Right target first
+	source.AddLink(link1) // Left target second
+	
+	t.Run("Links sorted by target position", func(t *testing.T) {
+		source.sortAllLinks()
+		
+		// After sorting, right target should come first (based on perpendicular projection)
+		index1, _ := link1.getLinkIndexAndCount(source, WINDROSE_S, true)
+		index2, _ := link2.getLinkIndexAndCount(source, WINDROSE_S, true)
+		
+		// The sorting uses perpendicular projection, so right target (higher X) comes first
+		if index2 >= index1 {
+			t.Errorf("Expected link2 (right target) to have lower index than link1 (left target), got %d >= %d", index2, index1)
+		}
+	})
+}
+
+func TestGetLinkIndexAndCount(t *testing.T) {
+	source := new(Resource).Init()
+	target := new(Resource).Init()
+	
+	// Create multiple links from different positions
+	linkS1 := new(Link).Init(source, WINDROSE_S, ArrowHead{}, target, WINDROSE_N, ArrowHead{}, 2, color.RGBA{0, 0, 0, 255})
+	linkS2 := new(Link).Init(source, WINDROSE_S, ArrowHead{}, target, WINDROSE_N, ArrowHead{}, 2, color.RGBA{0, 0, 0, 255})
+	linkE := new(Link).Init(source, WINDROSE_E, ArrowHead{}, target, WINDROSE_W, ArrowHead{}, 2, color.RGBA{0, 0, 0, 255})
+	
+	source.AddLink(linkS1)
+	source.AddLink(linkS2)
+	source.AddLink(linkE)
+	
+	t.Run("Count links from same position", func(t *testing.T) {
+		_, countS := linkS1.getLinkIndexAndCount(source, WINDROSE_S, true)
+		_, countE := linkE.getLinkIndexAndCount(source, WINDROSE_E, true)
+		
+		if countS != 2 {
+			t.Errorf("Expected 2 links from S position, got %d", countS)
+		}
+		if countE != 1 {
+			t.Errorf("Expected 1 link from E position, got %d", countE)
+		}
+	})
+}

--- a/internal/types/link_test.go
+++ b/internal/types/link_test.go
@@ -1898,6 +1898,9 @@ func TestGroupingOffset(t *testing.T) {
 
 	// Test normal grouping offset
 	t.Run("Normal grouping offset", func(t *testing.T) {
+		// Enable grouping offset
+		source.SetEnableGroupingOffset(true)
+
 		// Sort links first
 		source.sortAllLinks()
 
@@ -1919,9 +1922,10 @@ func TestGroupingOffset(t *testing.T) {
 		}
 	})
 
-	// Test disabled grouping offset
+	// Test disabled grouping offset (default behavior)
 	t.Run("Disabled grouping offset", func(t *testing.T) {
-		source.SetDisableGroupingOffset(true)
+		// Explicitly disable grouping offset
+		source.SetEnableGroupingOffset(false)
 
 		pt1 := link1.calcPositionWithOffset(source.GetBindings(), WINDROSE_S, source, true)
 		originalPt, _ := calcPosition(source.GetBindings(), WINDROSE_S)
@@ -1954,6 +1958,8 @@ func TestLinkSorting(t *testing.T) {
 	source.AddLink(link1) // Left target second
 
 	t.Run("Links sorted by target position", func(t *testing.T) {
+		// Enable grouping offset for this test
+		source.SetEnableGroupingOffset(true)
 		source.sortAllLinks()
 
 		// After sorting, right target should come first (based on perpendicular projection)

--- a/internal/types/link_test.go
+++ b/internal/types/link_test.go
@@ -1899,7 +1899,7 @@ func TestGroupingOffset(t *testing.T) {
 	// Test normal grouping offset
 	t.Run("Normal grouping offset", func(t *testing.T) {
 		// Enable grouping offset
-		source.SetEnableGroupingOffset(true)
+		source.SetGroupingOffset(true)
 
 		// Sort links first
 		source.sortAllLinks()
@@ -1925,7 +1925,7 @@ func TestGroupingOffset(t *testing.T) {
 	// Test disabled grouping offset (default behavior)
 	t.Run("Disabled grouping offset", func(t *testing.T) {
 		// Explicitly disable grouping offset
-		source.SetEnableGroupingOffset(false)
+		source.SetGroupingOffset(false)
 
 		pt1 := link1.calcPositionWithOffset(source.GetBindings(), WINDROSE_S, source, true)
 		originalPt, _ := calcPosition(source.GetBindings(), WINDROSE_S)
@@ -1959,7 +1959,7 @@ func TestLinkSorting(t *testing.T) {
 
 	t.Run("Links sorted by target position", func(t *testing.T) {
 		// Enable grouping offset for this test
-		source.SetEnableGroupingOffset(true)
+		source.SetGroupingOffset(true)
 		source.sortAllLinks()
 
 		// After sorting, right target should come first (based on perpendicular projection)

--- a/internal/types/link_test.go
+++ b/internal/types/link_test.go
@@ -1880,55 +1880,55 @@ func TestGroupingOffset(t *testing.T) {
 	// Setup resources
 	source := new(Resource).Init()
 	source.SetBindings(image.Rect(0, 0, 64, 64))
-	
+
 	target1 := new(Resource).Init()
 	target1.SetBindings(image.Rect(100, 0, 164, 64))
-	
+
 	target2 := new(Resource).Init()
 	target2.SetBindings(image.Rect(200, 0, 264, 64))
-	
+
 	// Create links from same source position
 	link1 := new(Link).Init(source, WINDROSE_S, ArrowHead{}, target1, WINDROSE_N, ArrowHead{}, 2, color.RGBA{0, 0, 0, 255})
 	link2 := new(Link).Init(source, WINDROSE_S, ArrowHead{}, target2, WINDROSE_N, ArrowHead{}, 2, color.RGBA{0, 0, 0, 255})
-	
+
 	source.AddLink(link1)
 	source.AddLink(link2)
 	target1.AddLink(link1)
 	target2.AddLink(link2)
-	
+
 	// Test normal grouping offset
 	t.Run("Normal grouping offset", func(t *testing.T) {
 		// Sort links first
 		source.sortAllLinks()
-		
+
 		// Test first link offset
 		index1, count1 := link1.getLinkIndexAndCount(source, WINDROSE_S, true)
 		if count1 != 2 {
 			t.Errorf("Expected count 2, got %d", count1)
 		}
-		
+
 		// Calculate expected offset: (index - (count-1)/2.0) * 10
 		expectedOffset1 := int((float64(index1) - float64(count1-1)/2.0) * 10)
-		
+
 		pt1 := link1.calcPositionWithOffset(source.GetBindings(), WINDROSE_S, source, true)
 		originalPt, _ := calcPosition(source.GetBindings(), WINDROSE_S)
-		
+
 		// Check if offset was applied
 		if pt1.X == originalPt.X && pt1.Y == originalPt.Y && expectedOffset1 != 0 {
 			t.Errorf("Expected offset to be applied, but position unchanged")
 		}
 	})
-	
+
 	// Test disabled grouping offset
 	t.Run("Disabled grouping offset", func(t *testing.T) {
 		source.SetDisableGroupingOffset(true)
-		
+
 		pt1 := link1.calcPositionWithOffset(source.GetBindings(), WINDROSE_S, source, true)
 		originalPt, _ := calcPosition(source.GetBindings(), WINDROSE_S)
-		
+
 		// Should use original position when disabled
 		if pt1.X != originalPt.X || pt1.Y != originalPt.Y {
-			t.Errorf("Expected original position (%d, %d), got (%d, %d)", 
+			t.Errorf("Expected original position (%d, %d), got (%d, %d)",
 				originalPt.X, originalPt.Y, pt1.X, pt1.Y)
 		}
 	})
@@ -1938,28 +1938,28 @@ func TestLinkSorting(t *testing.T) {
 	// Setup resources with different X positions
 	source := new(Resource).Init()
 	source.SetBindings(image.Rect(100, 0, 164, 64))
-	
+
 	target1 := new(Resource).Init()
-	target1.SetBindings(image.Rect(0, 100, 64, 164))    // Left target
-	
+	target1.SetBindings(image.Rect(0, 100, 64, 164)) // Left target
+
 	target2 := new(Resource).Init()
 	target2.SetBindings(image.Rect(200, 100, 264, 164)) // Right target
-	
+
 	// Create links
 	link1 := new(Link).Init(source, WINDROSE_S, ArrowHead{}, target1, WINDROSE_N, ArrowHead{}, 2, color.RGBA{0, 0, 0, 255})
 	link2 := new(Link).Init(source, WINDROSE_S, ArrowHead{}, target2, WINDROSE_N, ArrowHead{}, 2, color.RGBA{0, 0, 0, 255})
-	
+
 	// Add in reverse order to test sorting
 	source.AddLink(link2) // Right target first
 	source.AddLink(link1) // Left target second
-	
+
 	t.Run("Links sorted by target position", func(t *testing.T) {
 		source.sortAllLinks()
-		
+
 		// After sorting, right target should come first (based on perpendicular projection)
 		index1, _ := link1.getLinkIndexAndCount(source, WINDROSE_S, true)
 		index2, _ := link2.getLinkIndexAndCount(source, WINDROSE_S, true)
-		
+
 		// The sorting uses perpendicular projection, so right target (higher X) comes first
 		if index2 >= index1 {
 			t.Errorf("Expected link2 (right target) to have lower index than link1 (left target), got %d >= %d", index2, index1)
@@ -1970,20 +1970,20 @@ func TestLinkSorting(t *testing.T) {
 func TestGetLinkIndexAndCount(t *testing.T) {
 	source := new(Resource).Init()
 	target := new(Resource).Init()
-	
+
 	// Create multiple links from different positions
 	linkS1 := new(Link).Init(source, WINDROSE_S, ArrowHead{}, target, WINDROSE_N, ArrowHead{}, 2, color.RGBA{0, 0, 0, 255})
 	linkS2 := new(Link).Init(source, WINDROSE_S, ArrowHead{}, target, WINDROSE_N, ArrowHead{}, 2, color.RGBA{0, 0, 0, 255})
 	linkE := new(Link).Init(source, WINDROSE_E, ArrowHead{}, target, WINDROSE_W, ArrowHead{}, 2, color.RGBA{0, 0, 0, 255})
-	
+
 	source.AddLink(linkS1)
 	source.AddLink(linkS2)
 	source.AddLink(linkE)
-	
+
 	t.Run("Count links from same position", func(t *testing.T) {
 		_, countS := linkS1.getLinkIndexAndCount(source, WINDROSE_S, true)
 		_, countE := linkE.getLinkIndexAndCount(source, WINDROSE_E, true)
-		
+
 		if countS != 2 {
 			t.Errorf("Expected 2 links from S position, got %d", countS)
 		}

--- a/internal/types/resource.go
+++ b/internal/types/resource.go
@@ -668,10 +668,11 @@ func (r *Resource) sortAllLinks() {
 			key = fmt.Sprintf("target_%d", link.TargetPosition)
 		}
 		if key != "" {
-			if _, ok := linkGroups[key]; !ok {
-				linkGroups[key] = make([]*Link, 0)
+			links, ok := linkGroups[key]
+			if !ok {
+				links = make([]*Link, 0)
 			}
-			linkGroups[key] = append(linkGroups[key], link)
+			linkGroups[key] = append(links, link)
 		}
 	}
 

--- a/internal/types/resource.go
+++ b/internal/types/resource.go
@@ -225,7 +225,7 @@ func (r *Resource) SetIconFill(t ICON_FILL_TYPE, color *color.RGBA) {
 	}
 }
 
-func (r *Resource) SetEnableGroupingOffset(enable bool) {
+func (r *Resource) SetGroupingOffset(enable bool) {
 	r.enableGroupingOffset = enable
 }
 

--- a/internal/types/resource.go
+++ b/internal/types/resource.go
@@ -668,6 +668,9 @@ func (r *Resource) sortAllLinks() {
 			key = fmt.Sprintf("target_%d", link.TargetPosition)
 		}
 		if key != "" {
+			if _, ok := linkGroups[key]; !ok {
+				linkGroups[key] = make([]*Link, 0)
+			}
 			linkGroups[key] = append(linkGroups[key], link)
 		}
 	}

--- a/internal/types/resource.go
+++ b/internal/types/resource.go
@@ -639,7 +639,7 @@ func (r *Resource) Draw(img *image.RGBA, parent *Resource) (*image.RGBA, error) 
 	}
 	r.drawn = true
 
-	// リンク描画前に事前ソート
+	// Pre-sort links before drawing
 	r.sortAllLinks()
 
 	for _, v := range r.links {
@@ -657,7 +657,7 @@ func (r *Resource) Draw(img *image.RGBA, parent *Resource) (*image.RGBA, error) 
 func (r *Resource) sortAllLinks() {
 	log.Infof("=== Sorting links for resource %p ===", r)
 
-	// 同じ位置のリンクをグループ化
+	// Group links by same position
 	linkGroups := make(map[string][]*Link)
 
 	for _, link := range r.links {
@@ -678,7 +678,7 @@ func (r *Resource) sortAllLinks() {
 
 	log.Infof("Found %d link groups", len(linkGroups))
 
-	// 各グループをソートして元の配列を更新
+	// Sort each group and update original array
 	for key, links := range linkGroups {
 		if len(links) <= 1 {
 			log.Infof("Group %s: only %d link, no sorting needed", key, len(links))
@@ -695,7 +695,7 @@ func (r *Resource) sortAllLinks() {
 			position = links[0].TargetPosition
 		}
 
-		// ソート前の順序をログ
+		// Log order before sorting
 		for i, link := range links {
 			var otherResource *Resource
 			var otherPos Windrose
@@ -721,7 +721,7 @@ func (r *Resource) sortAllLinks() {
 				pt2, _ = calcPosition(links[j].Source.GetBindings(), links[j].SourcePosition)
 			}
 
-			// 方向ベクトルの直交方向でソート
+			// Sort by perpendicular direction of direction vector
 			direction := getDirectionVectorStatic(int(position))
 			perpendicular := direction.Perpendicular()
 
@@ -734,7 +734,7 @@ func (r *Resource) sortAllLinks() {
 			return proj1 < proj2
 		})
 
-		// ソート後の順序をログ
+		// Log order after sorting
 		for i, link := range links {
 			var otherResource *Resource
 			var otherPos Windrose
@@ -750,17 +750,17 @@ func (r *Resource) sortAllLinks() {
 				i, getResourceName(link.Source), getResourceName(link.Target), pt.X, pt.Y)
 		}
 
-		// ソート結果を元の配列に反映
+		// Apply sort results to original array
 		r.updateLinksOrder(links, key)
 	}
 	log.Infof("=== End sorting ===")
 }
 
 func (r *Resource) updateLinksOrder(sortedLinks []*Link, groupKey string) {
-	// 元の配列でソート対象のリンクを新しい順序で置き換え
+	// Replace links in original array with new order for sort targets
 	newLinks := make([]*Link, 0, len(r.links))
 
-	// ソート対象外のリンクを先に追加
+	// Add non-sort target links first
 	for _, link := range r.links {
 		var key string
 		if link.Source == r {
@@ -774,7 +774,7 @@ func (r *Resource) updateLinksOrder(sortedLinks []*Link, groupKey string) {
 		}
 	}
 
-	// ソート済みのリンクを追加
+	// Add sorted links
 	newLinks = append(newLinks, sortedLinks...)
 
 	r.links = newLinks

--- a/internal/types/resource.go
+++ b/internal/types/resource.go
@@ -41,25 +41,25 @@ const (
 )
 
 type Resource struct {
-	bindings       *image.Rectangle
-	iconImage      image.Image
-	iconBounds     image.Rectangle
-	borderColor    *color.RGBA
-	borderType     BORDER_TYPE
-	fillColor      color.RGBA
-	label          string
-	labelFont      string
-	labelColor     *color.RGBA
-	headerAlign    string // left(default) / center / right
-	margin         *Margin
-	padding        *Padding
-	direction      string
-	align          string
-	links          []*Link
-	children       []*Resource
-	borderChildren []*BorderChild
-	iconfill       ResourceIconFill
-	drawn          bool
+	bindings              *image.Rectangle
+	iconImage             image.Image
+	iconBounds            image.Rectangle
+	borderColor           *color.RGBA
+	borderType            BORDER_TYPE
+	fillColor             color.RGBA
+	label                 string
+	labelFont             string
+	labelColor            *color.RGBA
+	headerAlign           string // left(default) / center / right
+	margin                *Margin
+	padding               *Padding
+	direction             string
+	align                 string
+	links                 []*Link
+	children              []*Resource
+	borderChildren        []*BorderChild
+	iconfill              ResourceIconFill
+	drawn                 bool
 	disableGroupingOffset bool // Flag: if true, disable grouping offset for links
 }
 
@@ -638,10 +638,10 @@ func (r *Resource) Draw(img *image.RGBA, parent *Resource) (*image.RGBA, error) 
 		}
 	}
 	r.drawn = true
-	
+
 	// リンク描画前に事前ソート
 	r.sortAllLinks()
-	
+
 	for _, v := range r.links {
 		source := *v.Source
 		target := *v.Target
@@ -656,10 +656,10 @@ func (r *Resource) Draw(img *image.RGBA, parent *Resource) (*image.RGBA, error) 
 
 func (r *Resource) sortAllLinks() {
 	log.Infof("=== Sorting links for resource %p ===", r)
-	
+
 	// 同じ位置のリンクをグループ化
 	linkGroups := make(map[string][]*Link)
-	
+
 	for _, link := range r.links {
 		var key string
 		if link.Source == r {
@@ -671,18 +671,18 @@ func (r *Resource) sortAllLinks() {
 			linkGroups[key] = append(linkGroups[key], link)
 		}
 	}
-	
+
 	log.Infof("Found %d link groups", len(linkGroups))
-	
+
 	// 各グループをソートして元の配列を更新
 	for key, links := range linkGroups {
 		if len(links) <= 1 {
 			log.Infof("Group %s: only %d link, no sorting needed", key, len(links))
 			continue
 		}
-		
+
 		log.Infof("Group %s: sorting %d links", key, len(links))
-		
+
 		isSource := strings.HasPrefix(key, "source_")
 		var position Windrose
 		if isSource {
@@ -690,7 +690,7 @@ func (r *Resource) sortAllLinks() {
 		} else {
 			position = links[0].TargetPosition
 		}
-		
+
 		// ソート前の順序をログ
 		for i, link := range links {
 			var otherResource *Resource
@@ -703,10 +703,10 @@ func (r *Resource) sortAllLinks() {
 				otherPos = link.SourcePosition
 			}
 			pt, _ := calcPosition(otherResource.GetBindings(), otherPos)
-			log.Infof("  Before sort [%d]: %s->%s, other pos: (%d, %d)", 
+			log.Infof("  Before sort [%d]: %s->%s, other pos: (%d, %d)",
 				i, getResourceName(link.Source), getResourceName(link.Target), pt.X, pt.Y)
 		}
-		
+
 		sort.Slice(links, func(i, j int) bool {
 			var pt1, pt2 image.Point
 			if isSource {
@@ -716,20 +716,20 @@ func (r *Resource) sortAllLinks() {
 				pt1, _ = calcPosition(links[i].Source.GetBindings(), links[i].SourcePosition)
 				pt2, _ = calcPosition(links[j].Source.GetBindings(), links[j].SourcePosition)
 			}
-			
+
 			// 方向ベクトルの直交方向でソート
 			direction := getDirectionVectorStatic(int(position))
 			perpendicular := direction.Perpendicular()
-			
+
 			proj1 := float64(pt1.X)*perpendicular.X + float64(pt1.Y)*perpendicular.Y
 			proj2 := float64(pt2.X)*perpendicular.X + float64(pt2.Y)*perpendicular.Y
-			
-			log.Infof("    Compare: pt1=(%d,%d) proj1=%.1f vs pt2=(%d,%d) proj2=%.1f -> %v", 
+
+			log.Infof("    Compare: pt1=(%d,%d) proj1=%.1f vs pt2=(%d,%d) proj2=%.1f -> %v",
 				pt1.X, pt1.Y, proj1, pt2.X, pt2.Y, proj2, proj1 < proj2)
-			
+
 			return proj1 < proj2
 		})
-		
+
 		// ソート後の順序をログ
 		for i, link := range links {
 			var otherResource *Resource
@@ -742,10 +742,10 @@ func (r *Resource) sortAllLinks() {
 				otherPos = link.SourcePosition
 			}
 			pt, _ := calcPosition(otherResource.GetBindings(), otherPos)
-			log.Infof("  After sort [%d]: %s->%s, other pos: (%d, %d)", 
+			log.Infof("  After sort [%d]: %s->%s, other pos: (%d, %d)",
 				i, getResourceName(link.Source), getResourceName(link.Target), pt.X, pt.Y)
 		}
-		
+
 		// ソート結果を元の配列に反映
 		r.updateLinksOrder(links, key)
 	}
@@ -755,7 +755,7 @@ func (r *Resource) sortAllLinks() {
 func (r *Resource) updateLinksOrder(sortedLinks []*Link, groupKey string) {
 	// 元の配列でソート対象のリンクを新しい順序で置き換え
 	newLinks := make([]*Link, 0, len(r.links))
-	
+
 	// ソート対象外のリンクを先に追加
 	for _, link := range r.links {
 		var key string
@@ -764,15 +764,15 @@ func (r *Resource) updateLinksOrder(sortedLinks []*Link, groupKey string) {
 		} else if link.Target == r {
 			key = fmt.Sprintf("target_%d", link.TargetPosition)
 		}
-		
+
 		if key != groupKey {
 			newLinks = append(newLinks, link)
 		}
 	}
-	
+
 	// ソート済みのリンクを追加
 	newLinks = append(newLinks, sortedLinks...)
-	
+
 	r.links = newLinks
 	log.Infof("Updated links order for group %s", groupKey)
 }
@@ -787,11 +787,16 @@ func getResourceName(r *Resource) string {
 func getDirectionVectorStatic(position int) vector.Vector {
 	fourWindrose := ((position + 2) % 16) / 4
 	switch fourWindrose {
-	case 0: return vector.New(0, -1) // North
-	case 1: return vector.New(1, 0)  // East  
-	case 2: return vector.New(0, 1)  // South
-	case 3: return vector.New(-1, 0) // West
-	default: return vector.New(0, -1)
+	case 0:
+		return vector.New(0, -1) // North
+	case 1:
+		return vector.New(1, 0) // East
+	case 2:
+		return vector.New(0, 1) // South
+	case 3:
+		return vector.New(-1, 0) // West
+	default:
+		return vector.New(0, -1)
 	}
 }
 

--- a/internal/types/resource.go
+++ b/internal/types/resource.go
@@ -41,26 +41,26 @@ const (
 )
 
 type Resource struct {
-	bindings             *image.Rectangle
-	iconImage            image.Image
-	iconBounds           image.Rectangle
-	borderColor          *color.RGBA
-	borderType           BORDER_TYPE
-	fillColor            color.RGBA
-	label                string
-	labelFont            string
-	labelColor           *color.RGBA
-	headerAlign          string // left(default) / center / right
-	margin               *Margin
-	padding              *Padding
-	direction            string
-	align                string
-	links                []*Link
-	children             []*Resource
-	borderChildren       []*BorderChild
-	iconfill             ResourceIconFill
-	drawn                bool
-	enableGroupingOffset bool // Flag: if true, enable grouping offset for links
+	bindings       *image.Rectangle
+	iconImage      image.Image
+	iconBounds     image.Rectangle
+	borderColor    *color.RGBA
+	borderType     BORDER_TYPE
+	fillColor      color.RGBA
+	label          string
+	labelFont      string
+	labelColor     *color.RGBA
+	headerAlign    string // left(default) / center / right
+	margin         *Margin
+	padding        *Padding
+	direction      string
+	align          string
+	links          []*Link
+	children       []*Resource
+	borderChildren []*BorderChild
+	iconfill       ResourceIconFill
+	drawn          bool
+	groupingOffset bool // Flag: if true, enable grouping offset for links
 }
 
 type ResourceIconFill struct {
@@ -226,7 +226,7 @@ func (r *Resource) SetIconFill(t ICON_FILL_TYPE, color *color.RGBA) {
 }
 
 func (r *Resource) SetGroupingOffset(enable bool) {
-	r.enableGroupingOffset = enable
+	r.groupingOffset = enable
 }
 
 func (r *Resource) AddLink(link *Link) {

--- a/internal/types/resource.go
+++ b/internal/types/resource.go
@@ -41,26 +41,26 @@ const (
 )
 
 type Resource struct {
-	bindings              *image.Rectangle
-	iconImage             image.Image
-	iconBounds            image.Rectangle
-	borderColor           *color.RGBA
-	borderType            BORDER_TYPE
-	fillColor             color.RGBA
-	label                 string
-	labelFont             string
-	labelColor            *color.RGBA
-	headerAlign           string // left(default) / center / right
-	margin                *Margin
-	padding               *Padding
-	direction             string
-	align                 string
-	links                 []*Link
-	children              []*Resource
-	borderChildren        []*BorderChild
-	iconfill              ResourceIconFill
-	drawn                 bool
-	disableGroupingOffset bool // Flag: if true, disable grouping offset for links
+	bindings             *image.Rectangle
+	iconImage            image.Image
+	iconBounds           image.Rectangle
+	borderColor          *color.RGBA
+	borderType           BORDER_TYPE
+	fillColor            color.RGBA
+	label                string
+	labelFont            string
+	labelColor           *color.RGBA
+	headerAlign          string // left(default) / center / right
+	margin               *Margin
+	padding              *Padding
+	direction            string
+	align                string
+	links                []*Link
+	children             []*Resource
+	borderChildren       []*BorderChild
+	iconfill             ResourceIconFill
+	drawn                bool
+	enableGroupingOffset bool // Flag: if true, enable grouping offset for links
 }
 
 type ResourceIconFill struct {
@@ -225,8 +225,8 @@ func (r *Resource) SetIconFill(t ICON_FILL_TYPE, color *color.RGBA) {
 	}
 }
 
-func (r *Resource) SetDisableGroupingOffset(disable bool) {
-	r.disableGroupingOffset = disable
+func (r *Resource) SetEnableGroupingOffset(enable bool) {
+	r.enableGroupingOffset = enable
 }
 
 func (r *Resource) AddLink(link *Link) {


### PR DESCRIPTION
## Summary
This PR adds a new feature to prevent overlapping links by applying grouping offsets when multiple links originate from or terminate at the same position on a resource.

## Changes
- **Link Grouping Offset**: Automatically calculates perpendicular offsets for links sharing the same position
- **Link Sorting**: Sorts links by target/source position for consistent ordering
- **Optional Feature**: Disabled by default, can be enabled via Options.EnableGroupingOffset
- **Safe Implementation**: Uses comma-ok idiom for map access safety

## Usage
```yaml
Resources:
  MyResource:
    Type: AWS::EC2::Instance
    Options:
      EnableGroupingOffset: true
```

## Testing
- ✅ All unit tests pass
- ✅ All functional tests pass (including privatelink.yaml)
- ✅ Go format and safety checks pass
- ✅ Backward compatibility maintained (default behavior unchanged)

## Implementation Details
- Offset calculation: (index - (count-1)/2.0) * 10 pixels
- Perpendicular direction based on link position (N/S/E/W)
- Links sorted by perpendicular projection for consistent grouping
- No impact on existing diagrams unless explicitly enabled

## Files Changed
- `internal/types/link.go`: Core offset calculation logic
- `internal/types/resource.go`: Link sorting and grouping functionality
- `internal/ctl/create.go`: Options processing for EnableGroupingOffset
- `internal/types/link_test.go`: Comprehensive test coverage