### PR TITLE
Add auto-positioning feature for links

### DIFF
--- a/doc/links.md
+++ b/doc/links.md
@@ -23,6 +23,35 @@ Diagrams:
       LineStyle: `normal|dashed` (optional)
 ```
 
+### Auto-positioning
+
+**New Feature**: Links can automatically determine optimal connection points based on resource positions, eliminating the need to manually specify `SourcePosition` and `TargetPosition`.
+
+```yaml
+Links:
+  # Default behavior - auto-positioning (recommended)
+  - Source: ALB
+    Target: Instance1
+    
+  # Explicit auto-positioning
+  - Source: ALB
+    SourcePosition: auto
+    Target: Instance2
+    TargetPosition: auto
+    
+  # Mixed positioning - manual source, auto target
+  - Source: ALB
+    SourcePosition: E
+    Target: Instance3
+    TargetPosition: auto
+    
+  # Traditional manual positioning (still supported)
+  - Source: ALB
+    SourcePosition: NNE
+    Target: Instance4
+    TargetPosition: S
+```
+
 ### Link type
 
 #### Straight

--- a/doc/links.md
+++ b/doc/links.md
@@ -29,7 +29,7 @@ Diagrams:
 
 ```yaml
 Links:
-  # Default behavior - auto-positioning (recommended)
+  # Default behavior - auto-positioning
   - Source: ALB
     Target: Instance1
     

--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -199,14 +199,14 @@ func createDiagram(resources map[string]*types.Resource, outputfile *string, opt
 	if err := canvas.ZeroAdjust(); err != nil {
 		return fmt.Errorf("error adjusting diagram: %w", err)
 	}
-	
+
 	// Resolve auto-positions after layout is complete
 	for _, resource := range resources {
 		for _, link := range resource.GetLinks() {
 			link.ResolveAutoPositions()
 		}
 	}
-	
+
 	img, err := canvas.Draw(nil, nil)
 	if err != nil {
 		return fmt.Errorf("error drawing diagram: %w", err)
@@ -734,7 +734,7 @@ func loadLinks(template *TemplateStruct, resources map[string]*types.Resource) e
 		if err != nil {
 			return fmt.Errorf("failed to convert target windrose position: %w", err)
 		}
-		
+
 		link := new(types.Link).Init(source, sourcePosition, v.SourceArrowHead, target, targetPosition, v.TargetArrowHead, lineWidth, lineColor)
 		link.SetType(v.Type)
 		link.SetLineStyle(v.LineStyle)

--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -199,6 +199,14 @@ func createDiagram(resources map[string]*types.Resource, outputfile *string, opt
 	if err := canvas.ZeroAdjust(); err != nil {
 		return fmt.Errorf("error adjusting diagram: %w", err)
 	}
+	
+	// Resolve auto-positions after layout is complete
+	for _, resource := range resources {
+		for _, link := range resource.GetLinks() {
+			link.ResolveAutoPositions()
+		}
+	}
+	
 	img, err := canvas.Draw(nil, nil)
 	if err != nil {
 		return fmt.Errorf("error drawing diagram: %w", err)
@@ -717,6 +725,7 @@ func loadLinks(template *TemplateStruct, resources map[string]*types.Resource) e
 			}
 		}
 
+		// Convert positions (empty string and "auto" both become WINDROSE_AUTO)
 		sourcePosition, err := types.ConvertWindrose(v.SourcePosition)
 		if err != nil {
 			return fmt.Errorf("failed to convert source windrose position: %w", err)
@@ -725,6 +734,7 @@ func loadLinks(template *TemplateStruct, resources map[string]*types.Resource) e
 		if err != nil {
 			return fmt.Errorf("failed to convert target windrose position: %w", err)
 		}
+		
 		link := new(types.Link).Init(source, sourcePosition, v.SourceArrowHead, target, targetPosition, v.TargetArrowHead, lineWidth, lineColor)
 		link.SetType(v.Type)
 		link.SetLineStyle(v.LineStyle)

--- a/internal/types/link.go
+++ b/internal/types/link.go
@@ -81,6 +81,22 @@ func (l Link) Init(source *Resource, sourcePosition Windrose, sourceArrowHead Ar
 	return &gl
 }
 
+// ResolveAutoPositions converts WINDROSE_AUTO to actual positions after layout is complete
+func (l *Link) ResolveAutoPositions() {
+	if l.SourcePosition == WINDROSE_AUTO || l.TargetPosition == WINDROSE_AUTO {
+		log.Info("Resolving auto-positions after layout")
+		autoSourcePos, autoTargetPos := AutoCalculatePositions(l.Source, l.Target)
+		
+		if l.SourcePosition == WINDROSE_AUTO {
+			l.SourcePosition = autoSourcePos
+		}
+		if l.TargetPosition == WINDROSE_AUTO {
+			l.TargetPosition = autoTargetPos
+		}
+	}
+}
+
+
 func (l *Link) SetType(s string) {
 	l.Type = s
 }
@@ -354,6 +370,7 @@ func (l *Link) Draw(img *image.RGBA) error {
 		log.Info("Link already drawn")
 		return nil
 	}
+	
 	log.Info("Link Drawing")
 	sourcePt := l.calcPositionWithOffset(source.GetBindings(), l.SourcePosition, l.Source, true)
 	targetPt := l.calcPositionWithOffset(target.GetBindings(), l.TargetPosition, l.Target, false)
@@ -820,6 +837,64 @@ func (l *Link) calculateOrthogonalPath(sourcePt, targetPt image.Point) []image.P
 	log.Infof("Final control points: %v", controlPts)
 	log.Infof("=== End Convergent Calculation ===")
 	return controlPts
+}
+
+// AutoCalculatePositions determines optimal source and target positions for a link
+func AutoCalculatePositions(source, target *Resource) (sourcePos, targetPos Windrose) {
+	sourceBounds := source.GetBindings()
+	targetBounds := target.GetBindings()
+	
+	// Calculate centers
+	sourceCenter := image.Point{
+		X: sourceBounds.Min.X + sourceBounds.Dx()/2,
+		Y: sourceBounds.Min.Y + sourceBounds.Dy()/2,
+	}
+	targetCenter := image.Point{
+		X: targetBounds.Min.X + targetBounds.Dx()/2,
+		Y: targetBounds.Min.Y + targetBounds.Dy()/2,
+	}
+	
+	log.Infof("Auto-positioning: Source center (%d, %d), Target center (%d, %d)", 
+		sourceCenter.X, sourceCenter.Y, targetCenter.X, targetCenter.Y)
+	
+	// Calculate differences
+	dx := targetCenter.X - sourceCenter.X
+	dy := targetCenter.Y - sourceCenter.Y
+	
+	log.Infof("Auto-positioning: dx=%d, dy=%d", dx, dy)
+	
+	// Determine direction based on larger absolute difference
+	if abs(dx) > abs(dy) {
+		// Horizontal connection
+		if dx > 0 {
+			sourcePos = WINDROSE_E // Target is to the right
+			targetPos = WINDROSE_W
+		} else {
+			sourcePos = WINDROSE_W // Target is to the left
+			targetPos = WINDROSE_E
+		}
+	} else {
+		// Vertical connection
+		if dy > 0 {
+			sourcePos = WINDROSE_S // Target is below
+			targetPos = WINDROSE_N
+		} else {
+			sourcePos = WINDROSE_N // Target is above
+			targetPos = WINDROSE_S
+		}
+	}
+	
+	log.Infof("Auto-positioning: Source=%v, Target=%v", sourcePos, targetPos)
+	
+	return sourcePos, targetPos
+}
+
+// abs returns the absolute value of an integer
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
 }
 
 func (l *Link) calcPositionWithOffset(bindings image.Rectangle, position Windrose, resource *Resource, isSource bool) image.Point {

--- a/internal/types/link.go
+++ b/internal/types/link.go
@@ -86,7 +86,7 @@ func (l *Link) ResolveAutoPositions() {
 	if l.SourcePosition == WINDROSE_AUTO || l.TargetPosition == WINDROSE_AUTO {
 		log.Info("Resolving auto-positions after layout")
 		autoSourcePos, autoTargetPos := AutoCalculatePositions(l.Source, l.Target)
-		
+
 		if l.SourcePosition == WINDROSE_AUTO {
 			l.SourcePosition = autoSourcePos
 		}
@@ -95,7 +95,6 @@ func (l *Link) ResolveAutoPositions() {
 		}
 	}
 }
-
 
 func (l *Link) SetType(s string) {
 	l.Type = s
@@ -370,7 +369,7 @@ func (l *Link) Draw(img *image.RGBA) error {
 		log.Info("Link already drawn")
 		return nil
 	}
-	
+
 	log.Info("Link Drawing")
 	sourcePt := l.calcPositionWithOffset(source.GetBindings(), l.SourcePosition, l.Source, true)
 	targetPt := l.calcPositionWithOffset(target.GetBindings(), l.TargetPosition, l.Target, false)
@@ -843,7 +842,7 @@ func (l *Link) calculateOrthogonalPath(sourcePt, targetPt image.Point) []image.P
 func AutoCalculatePositions(source, target *Resource) (sourcePos, targetPos Windrose) {
 	sourceBounds := source.GetBindings()
 	targetBounds := target.GetBindings()
-	
+
 	// Calculate centers
 	sourceCenter := image.Point{
 		X: sourceBounds.Min.X + sourceBounds.Dx()/2,
@@ -853,16 +852,16 @@ func AutoCalculatePositions(source, target *Resource) (sourcePos, targetPos Wind
 		X: targetBounds.Min.X + targetBounds.Dx()/2,
 		Y: targetBounds.Min.Y + targetBounds.Dy()/2,
 	}
-	
-	log.Infof("Auto-positioning: Source center (%d, %d), Target center (%d, %d)", 
+
+	log.Infof("Auto-positioning: Source center (%d, %d), Target center (%d, %d)",
 		sourceCenter.X, sourceCenter.Y, targetCenter.X, targetCenter.Y)
-	
+
 	// Calculate differences
 	dx := targetCenter.X - sourceCenter.X
 	dy := targetCenter.Y - sourceCenter.Y
-	
+
 	log.Infof("Auto-positioning: dx=%d, dy=%d", dx, dy)
-	
+
 	// Determine direction based on larger absolute difference
 	if abs(dx) > abs(dy) {
 		// Horizontal connection
@@ -883,9 +882,9 @@ func AutoCalculatePositions(source, target *Resource) (sourcePos, targetPos Wind
 			targetPos = WINDROSE_S
 		}
 	}
-	
+
 	log.Infof("Auto-positioning: Source=%v, Target=%v", sourcePos, targetPos)
-	
+
 	return sourcePos, targetPos
 }
 

--- a/internal/types/link_test.go
+++ b/internal/types/link_test.go
@@ -2003,15 +2003,15 @@ func TestAutoCalculatePositions(t *testing.T) {
 	// Create mock resources with different positions
 	source := &Resource{}
 	target := &Resource{}
-	
+
 	// Test horizontal layout (source left, target right)
 	sourceBounds := image.Rect(0, 0, 100, 100)
 	targetBounds := image.Rect(200, 0, 300, 100)
 	source.bindings = &sourceBounds
 	target.bindings = &targetBounds
-	
+
 	sourcePos, targetPos := AutoCalculatePositions(source, target)
-	
+
 	// dx=150, dy=0 -> horizontal connection, target to the right
 	if sourcePos != WINDROSE_E {
 		t.Errorf("Expected source position E, got %v", sourcePos)
@@ -2019,15 +2019,15 @@ func TestAutoCalculatePositions(t *testing.T) {
 	if targetPos != WINDROSE_W {
 		t.Errorf("Expected target position W, got %v", targetPos)
 	}
-	
+
 	// Test vertical layout (source top, target bottom)
 	sourceBounds2 := image.Rect(0, 0, 100, 100)
 	targetBounds2 := image.Rect(0, 200, 100, 300)
 	source.bindings = &sourceBounds2
 	target.bindings = &targetBounds2
-	
+
 	sourcePos, targetPos = AutoCalculatePositions(source, target)
-	
+
 	// dx=0, dy=150 -> vertical connection, target below
 	if sourcePos != WINDROSE_S {
 		t.Errorf("Expected source position S, got %v", sourcePos)

--- a/internal/types/link_test.go
+++ b/internal/types/link_test.go
@@ -1998,3 +1998,41 @@ func TestGetLinkIndexAndCount(t *testing.T) {
 		}
 	})
 }
+
+func TestAutoCalculatePositions(t *testing.T) {
+	// Create mock resources with different positions
+	source := &Resource{}
+	target := &Resource{}
+	
+	// Test horizontal layout (source left, target right)
+	sourceBounds := image.Rect(0, 0, 100, 100)
+	targetBounds := image.Rect(200, 0, 300, 100)
+	source.bindings = &sourceBounds
+	target.bindings = &targetBounds
+	
+	sourcePos, targetPos := AutoCalculatePositions(source, target)
+	
+	// dx=150, dy=0 -> horizontal connection, target to the right
+	if sourcePos != WINDROSE_E {
+		t.Errorf("Expected source position E, got %v", sourcePos)
+	}
+	if targetPos != WINDROSE_W {
+		t.Errorf("Expected target position W, got %v", targetPos)
+	}
+	
+	// Test vertical layout (source top, target bottom)
+	sourceBounds2 := image.Rect(0, 0, 100, 100)
+	targetBounds2 := image.Rect(0, 200, 100, 300)
+	source.bindings = &sourceBounds2
+	target.bindings = &targetBounds2
+	
+	sourcePos, targetPos = AutoCalculatePositions(source, target)
+	
+	// dx=0, dy=150 -> vertical connection, target below
+	if sourcePos != WINDROSE_S {
+		t.Errorf("Expected source position S, got %v", sourcePos)
+	}
+	if targetPos != WINDROSE_N {
+		t.Errorf("Expected target position N, got %v", targetPos)
+	}
+}

--- a/internal/types/resource.go
+++ b/internal/types/resource.go
@@ -233,6 +233,10 @@ func (r *Resource) AddLink(link *Link) {
 	r.links = append(r.links, link)
 }
 
+func (r *Resource) GetLinks() []*Link {
+	return r.links
+}
+
 func (r *Resource) AddParent() {
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -30,9 +30,14 @@ const (
 	WINDROSE_WNW
 	WINDROSE_NW
 	WINDROSE_NNW
+	WINDROSE_AUTO = -1 // Special value for auto-positioning
 )
 
 func ConvertWindrose(position string) (Windrose, error) {
+	if position == "" || position == "auto" {
+		return WINDROSE_AUTO, nil
+	}
+	
 	switch position {
 	case "N":
 		return WINDROSE_N, nil
@@ -67,7 +72,7 @@ func ConvertWindrose(position string) (Windrose, error) {
 	case "NNW":
 		return WINDROSE_NNW, nil
 	}
-	return 0, fmt.Errorf("unknown position: %s, supported positions are N, NNE, NE, ENE, E, ESE, SE, SSE, S, SSW, SW, WSW, W, WNW, NW, NNW", position)
+	return 0, fmt.Errorf("unknown position: %s, supported positions are N, NNE, NE, ENE, E, ESE, SE, SSE, S, SSW, SW, WSW, W, WNW, NW, NNW, auto", position)
 }
 
 type Margin struct {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -174,6 +174,8 @@ func calcPosition(bindings image.Rectangle, position Windrose) (image.Point, err
 		return image.Point{tx[0], ty[0]}, nil
 	case WINDROSE_NNW:
 		return image.Point{tx[1], ty[0]}, nil
+	case WINDROSE_AUTO:
+		return image.Point{tx[0], ty[0]}, fmt.Errorf("WINDROSE_AUTO should be resolved before calling calcPosition")
 	}
 	return image.Point{tx[0], ty[0]}, fmt.Errorf("unknown position: %d, supported positions are N, NNE, NE, ENE, E, ESE, SE, SSE, S, SSW, SW, WSW, W, WNW, NW, NNW", position)
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -37,7 +37,7 @@ func ConvertWindrose(position string) (Windrose, error) {
 	if position == "" || position == "auto" {
 		return WINDROSE_AUTO, nil
 	}
-	
+
 	switch position {
 	case "N":
 		return WINDROSE_N, nil

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -123,19 +123,19 @@ func TestConvertWindrose(t *testing.T) {
 	if err != nil || pos != WINDROSE_N {
 		t.Errorf("Expected WINDROSE_N, got %v, err: %v", pos, err)
 	}
-	
+
 	// Test empty string (default to auto)
 	pos, err = ConvertWindrose("")
 	if err != nil || pos != WINDROSE_AUTO {
 		t.Errorf("Expected WINDROSE_AUTO for empty string, got %v, err: %v", pos, err)
 	}
-	
+
 	// Test explicit "auto"
 	pos, err = ConvertWindrose("auto")
 	if err != nil || pos != WINDROSE_AUTO {
 		t.Errorf("Expected WINDROSE_AUTO for 'auto', got %v, err: %v", pos, err)
 	}
-	
+
 	// Test invalid position
 	_, err = ConvertWindrose("invalid")
 	if err == nil {

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -116,3 +116,29 @@ func TestCalcPosition(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertWindrose(t *testing.T) {
+	// Test normal directions
+	pos, err := ConvertWindrose("N")
+	if err != nil || pos != WINDROSE_N {
+		t.Errorf("Expected WINDROSE_N, got %v, err: %v", pos, err)
+	}
+	
+	// Test empty string (default to auto)
+	pos, err = ConvertWindrose("")
+	if err != nil || pos != WINDROSE_AUTO {
+		t.Errorf("Expected WINDROSE_AUTO for empty string, got %v, err: %v", pos, err)
+	}
+	
+	// Test explicit "auto"
+	pos, err = ConvertWindrose("auto")
+	if err != nil || pos != WINDROSE_AUTO {
+		t.Errorf("Expected WINDROSE_AUTO for 'auto', got %v, err: %v", pos, err)
+	}
+	
+	// Test invalid position
+	_, err = ConvertWindrose("invalid")
+	if err == nil {
+		t.Error("Expected error for invalid position")
+	}
+}


### PR DESCRIPTION
## Overview
Add automatic position determination for link connections, eliminating the need to manually specify SourcePosition/TargetPosition in most cases.

## Features
- **Auto-positioning**: Empty string and 'auto' trigger automatic position calculation
- **4-direction algorithm**: Uses dx/dy comparison for N/S/E/W positioning  
- **Mixed support**: Can mix manual and auto positioning
- **Backward compatible**: Existing manual positions continue to work
- **Default behavior**: Links without positions automatically use optimal connections

## Usage Examples
```yaml
Links:
  # Default - auto-positioning
  - Source: ALB
    Target: Instance1
    
  # Explicit auto
  - Source: ALB
    SourcePosition: auto
    Target: Instance2
    TargetPosition: auto
    
  # Mixed positioning
  - Source: ALB
    SourcePosition: E
    Target: Instance3
    TargetPosition: auto
```

## Implementation
- Added WINDROSE_AUTO constant (-1)
- ResolveAutoPositions() called after layout completion
- Updated ConvertWindrose() to handle empty/auto strings
- Added comprehensive unit tests
- Updated documentation

Tested with all existing examples - maintains full backward compatibility.