### PR TITLE
Replace fmt.Printf with log in internal/ctl to prevent MCP server stdio conflicts

### DIFF
--- a/cmd/awsdac/main.go
+++ b/cmd/awsdac/main.go
@@ -72,6 +72,7 @@ func main() {
 				if err := ctl.CreateDiagramFromCFnTemplate(inputFile, &outputFile, generateDacFile, &opts); err != nil {
 					return fmt.Errorf("failed to create diagram from CloudFormation template: %w", err)
 				}
+				fmt.Printf("[Completed] AWS infrastructure diagram generated: %s\n", outputFile)
 			} else {
 				opts := ctl.CreateOptions{
 					IsGoTemplate:    isGoTemplate,
@@ -87,6 +88,7 @@ func main() {
 				if err := ctl.CreateDiagramFromDacFile(inputFile, &outputFile, &opts); err != nil {
 					return fmt.Errorf("failed to create diagram: %w", err)
 				}
+				fmt.Printf("[Completed] AWS infrastructure diagram generated: %s\n", outputFile)
 			}
 
 			return nil

--- a/internal/ctl/cfntemplate.go
+++ b/internal/ctl/cfntemplate.go
@@ -341,7 +341,7 @@ func generateDacFileFromCFnTemplate(template *TemplateStruct, outputfile string)
 
 	yamlData, err := yaml.Marshal(template)
 	if err != nil {
-		fmt.Printf("Error while marshaling data: %v", err)
+		log.Errorf("Error while marshaling data: %v", err)
 		return
 	}
 
@@ -350,7 +350,7 @@ func generateDacFileFromCFnTemplate(template *TemplateStruct, outputfile string)
 
 	err = os.WriteFile(outputYamlFile, yamlData, 0644)
 	if err != nil {
-		fmt.Printf("Error while writing to file: %v", err)
+		log.Errorf("Error while writing to file: %v", err)
 		return
 	}
 
@@ -388,7 +388,7 @@ func findRefs(t map[string]interface{}, fromName string) []string {
 					refs = append(refs, s)
 				}
 			default:
-				fmt.Printf("Malformed GetAtt: %T\n", v)
+				log.Warnf("Malformed GetAtt: %T\n", v)
 			}
 		case "Fn::Sub":
 			switch v := value.(type) {
@@ -399,7 +399,7 @@ func findRefs(t map[string]interface{}, fromName string) []string {
 			case []interface{}:
 				switch {
 				case len(v) != 2:
-					fmt.Printf("Malformed Sub: %T\n", v)
+					log.Warnf("Malformed Sub: %T\n", v)
 				default:
 					switch parts := v[1].(type) {
 					case map[string]interface{}:
@@ -408,15 +408,15 @@ func findRefs(t map[string]interface{}, fromName string) []string {
 							case map[string]interface{}:
 								refs = append(refs, findRefs(p, fromName)...)
 							default:
-								fmt.Printf("Malformed Sub: %T\n", v)
+								log.Warnf("Malformed Sub: %T\n", v)
 							}
 						}
 					default:
-						fmt.Printf("Malformed Sub: %T\n", v)
+						log.Warnf("Malformed Sub: %T\n", v)
 					}
 				}
 			default:
-				fmt.Printf("Malformed Sub: %T\n", v)
+				log.Warnf("Malformed Sub: %T\n", v)
 			}
 		default:
 			for _, tree := range findTrees(value) {

--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -220,7 +220,6 @@ func createDiagram(resources map[string]*types.Resource, outputfile *string, opt
 	}
 
 	log.Infof("Save %s\n", *outputfile)
-	fmt.Printf("[Completed] AWS infrastructure diagram generated: %s\n", *outputfile)
 	f, err := os.OpenFile(*outputfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("error opening output file: %w", err)


### PR DESCRIPTION
## Problem
MCP server uses stdio for communication, but `fmt.Printf` calls in `internal/ctl` package were writing to stdout, causing conflicts with the MCP protocol.

## Changes
- Removed completed message from `createDiagram()` shared function
- Added completed messages in CLI (`cmd/awsdac/main.go`) after function calls
- Replaced `fmt.Printf` with `log.Errorf`/`Warnf` in `cfntemplate.go`
- Kept `fmt.Printf` in `generateDacFileFromCFnTemplate` (CLI-only goroutine)
- Kept `fmt.Printf` in `askOverwriteConfirmation` (not used by MCP server)

## Result
- MCP server: stdout is not polluted, stdio communication is protected
- CLI: completion messages are properly displayed to users