### PR TITLE
Add URL validation for definition files with --allow-untrusted-definitions flag

### DIFF
--- a/cmd/awsdac/main.go
+++ b/cmd/awsdac/main.go
@@ -21,6 +21,7 @@ func main() {
 	var cfnTemplate bool
 	var generateDacFile bool
 	var overrideDefFile string
+	var allowUntrustedDefinitions bool
 	var isGoTemplate bool
 	var force bool
 	var width int
@@ -60,9 +61,10 @@ func main() {
 
 			if cfnTemplate {
 				opts := ctl.CreateOptions{
-					OverrideDefFile: overrideDefFile,
-					Width:           width,
-					Height:          height,
+					OverrideDefFile:           overrideDefFile,
+					AllowUntrustedDefinitions: allowUntrustedDefinitions,
+					Width:                     width,
+					Height:                    height,
 				}
 				if force {
 					opts.OverwriteMode = ctl.Force
@@ -75,10 +77,11 @@ func main() {
 				fmt.Printf("[Completed] AWS infrastructure diagram generated: %s\n", outputFile)
 			} else {
 				opts := ctl.CreateOptions{
-					IsGoTemplate:    isGoTemplate,
-					OverrideDefFile: overrideDefFile,
-					Width:           width,
-					Height:          height,
+					IsGoTemplate:              isGoTemplate,
+					OverrideDefFile:           overrideDefFile,
+					AllowUntrustedDefinitions: allowUntrustedDefinitions,
+					Width:                     width,
+					Height:                    height,
 				}
 				if force {
 					opts.OverwriteMode = ctl.Force
@@ -100,6 +103,7 @@ func main() {
 	rootCmd.PersistentFlags().BoolVarP(&cfnTemplate, "cfn-template", "c", false, "[beta] Create diagram from CloudFormation template")
 	rootCmd.PersistentFlags().BoolVarP(&generateDacFile, "dac-file", "d", false, "[beta] Generate YAML file in dac (diagram-as-code) format from CloudFormation template")
 	rootCmd.PersistentFlags().StringVarP(&overrideDefFile, "override-def-file", "", "", "For testing purpose, override DefinitionFiles to another url/local file")
+	rootCmd.PersistentFlags().BoolVarP(&allowUntrustedDefinitions, "allow-untrusted-definitions", "", false, "Allow loading definition files from untrusted URLs (not from official repository)")
 	rootCmd.PersistentFlags().BoolVarP(&isGoTemplate, "template", "t", false, "Processes the input file as a template according to text/template.")
 	rootCmd.PersistentFlags().BoolVarP(&force, "force", "f", false, "Overwrite output file without confirmation")
 	rootCmd.PersistentFlags().IntVar(&width, "width", 0, "Resize output image width (0 means no resizing)")

--- a/internal/ctl/cfntemplate.go
+++ b/internal/ctl/cfntemplate.go
@@ -101,12 +101,13 @@ func CreateDiagramFromCFnTemplate(inputfile string, outputfile *string, generate
 			}
 			overrideDefTemplate.DefinitionFiles = append(overrideDefTemplate.DefinitionFiles, defFile)
 		}
-		if err := loadDefinitionFiles(&overrideDefTemplate, &ds); err != nil {
+		// OverrideDefFile is for testing, so allow untrusted URLs
+		if err := loadDefinitionFiles(&overrideDefTemplate, &ds, true); err != nil {
 			return fmt.Errorf("failed to load override definition files: %w", err)
 		}
 		log.Infof("overrideDefTemplate: %+v", overrideDefTemplate)
 	} else {
-		if err := loadDefinitionFiles(&template, &ds); err != nil {
+		if err := loadDefinitionFiles(&template, &ds, opts.AllowUntrustedDefinitions); err != nil {
 			return fmt.Errorf("failed to load definition files: %w", err)
 		}
 	}

--- a/internal/ctl/create_test.go
+++ b/internal/ctl/create_test.go
@@ -277,3 +277,56 @@ func TestLoadResourcesWithNoFallbackPossible(t *testing.T) {
 		t.Error("Canvas resource should still be created")
 	}
 }
+
+func TestIsAllowedDefinitionURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{
+			name:    "official raw.githubusercontent.com URL",
+			url:     "https://raw.githubusercontent.com/awslabs/diagram-as-code/main/definitions/definition-for-aws-icons-light.yaml",
+			wantErr: false,
+		},
+		{
+			name:    "official github.com URL",
+			url:     "https://github.com/awslabs/diagram-as-code/releases/download/v1.0.0/definitions.yaml",
+			wantErr: false,
+		},
+		{
+			name:    "untrusted URL",
+			url:     "https://example.com/malicious-definitions.yaml",
+			wantErr: true,
+		},
+		{
+			name:    "localhost URL",
+			url:     "http://localhost:8080/definitions.yaml",
+			wantErr: true,
+		},
+		{
+			name:    "private IP URL",
+			url:     "http://192.168.1.1/definitions.yaml",
+			wantErr: true,
+		},
+		{
+			name:    "different github org",
+			url:     "https://raw.githubusercontent.com/other-org/diagram-as-code/main/definitions.yaml",
+			wantErr: true,
+		},
+		{
+			name:    "different github repo",
+			url:     "https://raw.githubusercontent.com/awslabs/other-repo/main/definitions.yaml",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := isAllowedDefinitionURL(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("isAllowedDefinitionURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/ctl/dacfile.go
+++ b/internal/ctl/dacfile.go
@@ -126,12 +126,13 @@ func CreateDiagramFromDacFile(inputfile string, outputfile *string, opts *Create
 			}
 			overrideDefTemplate.DefinitionFiles = append(overrideDefTemplate.DefinitionFiles, defFile)
 		}
-		if err := loadDefinitionFiles(&overrideDefTemplate, &ds); err != nil {
+		// OverrideDefFile is for testing, so allow untrusted URLs
+		if err := loadDefinitionFiles(&overrideDefTemplate, &ds, true); err != nil {
 			return fmt.Errorf("failed to load override definition files: %w", err)
 		}
 		log.Infof("overrideDefTemplate: %+v", overrideDefTemplate)
 	} else {
-		if err := loadDefinitionFiles(&template, &ds); err != nil {
+		if err := loadDefinitionFiles(&template, &ds, opts.AllowUntrustedDefinitions); err != nil {
 			return fmt.Errorf("failed to load definition files: %w", err)
 		}
 	}


### PR DESCRIPTION
## Summary
This PR adds security validation for definition file URLs to prevent loading untrusted definition files.

## Changes
- Add `isAllowedDefinitionURL()` to restrict definition file URLs to official repository only
- Add `--allow-untrusted-definitions` flag to allow untrusted URLs when explicitly needed
- Update `loadDefinitionFiles()` to validate URLs by default
- Keep `--override-def-file` unrestricted for testing purposes
- Add comprehensive tests for URL validation

## Security
By default, only definition files from the official repository (`https://github.com/awslabs/diagram-as-code/`) are allowed. Users must explicitly use `--allow-untrusted-definitions` to load from other sources.

## Testing
- All existing tests pass
- Added 7 new test cases for URL validation