### PR TITLE
feat: Save diagram YAML content as PNG metadata and add extract CLI command

### DIFF
--- a/cmd/awsdac/main.go
+++ b/cmd/awsdac/main.go
@@ -109,6 +109,22 @@ func main() {
 	rootCmd.PersistentFlags().IntVar(&width, "width", 0, "Resize output image width (0 means no resizing)")
 	rootCmd.PersistentFlags().IntVar(&height, "height", 0, "Resize output image height (0 means no resizing)")
 
+	var extractCmd = &cobra.Command{
+		Use:   "extract <png file>",
+		Short: "Extract YAML diagram-as-code configuration from a generated PNG file",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pngFile := args[0]
+			yamlContent, err := ctl.ExtractYAMLFromPNGFile(pngFile)
+			if err != nil {
+				return err
+			}
+			fmt.Print(string(yamlContent))
+			return nil
+		},
+	}
+	rootCmd.AddCommand(extractCmd)
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/internal/ctl/cfntemplate.go
+++ b/internal/ctl/cfntemplate.go
@@ -137,6 +137,15 @@ func CreateDiagramFromCFnTemplate(inputfile string, outputfile *string, generate
 		go generateDacFileFromCFnTemplate(&template, *outputfile)
 	}
 
+	if opts != nil {
+		yamlBytes, err := yaml.Marshal(template)
+		if err == nil {
+			opts.YAMLContent = yamlBytes
+		} else {
+			log.Warnf("Failed to marshal generated DAC template to YAML: %v", err)
+		}
+	}
+
 	if err := createDiagram(resources, outputfile, opts); err != nil {
 		return fmt.Errorf("failed to create diagram: %w", err)
 	}

--- a/internal/ctl/create.go
+++ b/internal/ctl/create.go
@@ -5,6 +5,7 @@ package ctl
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"image"
 	"image/color"
@@ -180,6 +181,7 @@ type CreateOptions struct {
 	OverrideFont              string
 	Width                     int
 	Height                    int
+	YAMLContent               []byte
 }
 
 func createDiagram(resources map[string]*types.Resource, outputfile *string, opts *CreateOptions) error {
@@ -250,18 +252,24 @@ func createDiagram(resources map[string]*types.Resource, outputfile *string, opt
 		img = resizedImg
 	}
 
-	log.Infof("Save %s\n", *outputfile)
-	f, err := os.OpenFile(*outputfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return fmt.Errorf("error opening output file: %w", err)
-	}
-	defer func() {
-		if closeErr := f.Close(); closeErr != nil {
-			log.Warnf("Failed to close output file: %v", closeErr)
-		}
-	}()
-	if err := png.Encode(f, img); err != nil {
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
 		return fmt.Errorf("error encoding PNG: %w", err)
+	}
+
+	pngBytes := buf.Bytes()
+	if opts != nil && len(opts.YAMLContent) > 0 {
+		embeddedBytes, err := EmbedYAMLInPNG(pngBytes, opts.YAMLContent)
+		if err != nil {
+			log.Warnf("Failed to embed YAML in PNG: %v", err)
+		} else {
+			pngBytes = embeddedBytes
+		}
+	}
+
+	log.Infof("Save %s\n", *outputfile)
+	if err := os.WriteFile(*outputfile, pngBytes, 0600); err != nil {
+		return fmt.Errorf("error writing PNG file: %w", err)
 	}
 	return nil
 }

--- a/internal/ctl/dacfile.go
+++ b/internal/ctl/dacfile.go
@@ -94,6 +94,10 @@ func CreateDiagramFromDacFile(inputfile string, outputfile *string, opts *Create
 		processedData = data
 	}
 
+	if opts != nil {
+		opts.YAMLContent = processedData
+	}
+
 	// Unmarshal the processed YAML
 	dec := yaml.NewDecoder(bytes.NewReader(processedData))
 	dec.KnownFields(true)

--- a/internal/ctl/metadata.go
+++ b/internal/ctl/metadata.go
@@ -1,0 +1,140 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ctl
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"os"
+)
+
+// EmbedYAMLInPNG embeds the YAML content in the PNG bytes.
+// It parses the PNG structure, and inserts a tEXt chunk containing base64-encoded YAML
+// immediately after the IHDR chunk.
+func EmbedYAMLInPNG(pngBytes []byte, yamlContent []byte) ([]byte, error) {
+	if len(pngBytes) < 8 {
+		return nil, fmt.Errorf("invalid PNG: too short")
+	}
+	pngSig := []byte{137, 80, 78, 71, 13, 10, 26, 10}
+	if !bytes.Equal(pngBytes[:8], pngSig) {
+		return nil, fmt.Errorf("invalid PNG signature")
+	}
+
+	b64YAML := base64.StdEncoding.EncodeToString(yamlContent)
+
+	keyword := []byte("awsdac")
+	chunkData := make([]byte, len(keyword)+1+len(b64YAML))
+	copy(chunkData[0:len(keyword)], keyword)
+	chunkData[len(keyword)] = 0x00
+	copy(chunkData[len(keyword)+1:], []byte(b64YAML))
+
+	chunkType := []byte("tEXt")
+	chunkLength := uint32(len(chunkData))
+
+	var chunkBuf bytes.Buffer
+	if err := binary.Write(&chunkBuf, binary.BigEndian, chunkLength); err != nil {
+		return nil, err
+	}
+	chunkBuf.Write(chunkType)
+	chunkBuf.Write(chunkData)
+
+	h := crc32.NewIEEE()
+	h.Write(chunkType)
+	h.Write(chunkData)
+	chunkCRC := h.Sum32()
+	if err := binary.Write(&chunkBuf, binary.BigEndian, chunkCRC); err != nil {
+		return nil, err
+	}
+	tEXtChunk := chunkBuf.Bytes()
+
+	var out bytes.Buffer
+	out.Write(pngSig)
+
+	offset := 8
+	ihdrFound := false
+
+	for offset < len(pngBytes) {
+		if offset+8 > len(pngBytes) {
+			return nil, fmt.Errorf("malformed PNG: unexpected end of file")
+		}
+		length := binary.BigEndian.Uint32(pngBytes[offset : offset+4])
+		chunkTypeStr := string(pngBytes[offset+4 : offset+8])
+		chunkTotalLength := int(4 + 4 + length + 4)
+
+		if offset+chunkTotalLength > len(pngBytes) {
+			return nil, fmt.Errorf("malformed PNG: chunk length exceeds file size")
+		}
+
+		out.Write(pngBytes[offset : offset+chunkTotalLength])
+		offset += chunkTotalLength
+
+		if chunkTypeStr == "IHDR" {
+			ihdrFound = true
+			out.Write(tEXtChunk)
+		}
+	}
+
+	if !ihdrFound {
+		return nil, fmt.Errorf("IHDR chunk not found in PNG")
+	}
+
+	return out.Bytes(), nil
+}
+
+// ExtractYAMLFromPNG extracts the base64-encoded YAML content from a PNG file/bytes.
+func ExtractYAMLFromPNG(pngBytes []byte) ([]byte, error) {
+	if len(pngBytes) < 8 {
+		return nil, fmt.Errorf("invalid PNG: too short")
+	}
+	pngSig := []byte{137, 80, 78, 71, 13, 10, 26, 10}
+	if !bytes.Equal(pngBytes[:8], pngSig) {
+		return nil, fmt.Errorf("invalid PNG signature")
+	}
+
+	offset := 8
+	for offset < len(pngBytes) {
+		if offset+8 > len(pngBytes) {
+			break
+		}
+		length := binary.BigEndian.Uint32(pngBytes[offset : offset+4])
+		chunkTypeStr := string(pngBytes[offset+4 : offset+8])
+		chunkTotalLength := int(4 + 4 + length + 4)
+
+		if offset+chunkTotalLength > len(pngBytes) {
+			return nil, fmt.Errorf("malformed PNG: chunk length exceeds file size")
+		}
+
+		if chunkTypeStr == "tEXt" {
+			data := pngBytes[offset+8 : offset+8+int(length)]
+			nullIdx := bytes.IndexByte(data, 0x00)
+			if nullIdx != -1 {
+				keyword := string(data[:nullIdx])
+				if keyword == "awsdac" {
+					b64YAML := string(data[nullIdx+1:])
+					yamlContent, err := base64.StdEncoding.DecodeString(b64YAML)
+					if err != nil {
+						return nil, fmt.Errorf("failed to decode base64 YAML: %w", err)
+					}
+					return yamlContent, nil
+				}
+			}
+		}
+
+		offset += chunkTotalLength
+	}
+
+	return nil, fmt.Errorf("no awsdac diagram-as-code YAML metadata found in PNG")
+}
+
+// ExtractYAMLFromPNGFile reads a PNG file and extracts the embedded YAML.
+func ExtractYAMLFromPNGFile(filename string) ([]byte, error) {
+	pngBytes, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read PNG file: %w", err)
+	}
+	return ExtractYAMLFromPNG(pngBytes)
+}

--- a/internal/ctl/metadata_test.go
+++ b/internal/ctl/metadata_test.go
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ctl
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+)
+
+func generateMinimalPNG() ([]byte, error) {
+	img := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.RGBA{R: 255, G: 0, B: 0, A: 255})
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func TestEmbedAndExtractYAML(t *testing.T) {
+	pngBytes, err := generateMinimalPNG()
+	if err != nil {
+		t.Fatalf("failed to generate test PNG: %v", err)
+	}
+
+	testYAML := []byte("Diagram:\n  Resources:\n    Test:\n      Type: AWS::Diagram::Resource")
+
+	embeddedPNG, err := EmbedYAMLInPNG(pngBytes, testYAML)
+	if err != nil {
+		t.Fatalf("failed to embed YAML in PNG: %v", err)
+	}
+
+	// Verify PNG signature is still intact
+	pngSig := []byte{137, 80, 78, 71, 13, 10, 26, 10}
+	if !bytes.HasPrefix(embeddedPNG, pngSig) {
+		t.Errorf("embedded PNG does not have valid PNG signature")
+	}
+
+	// Extract and verify
+	extractedYAML, err := ExtractYAMLFromPNG(embeddedPNG)
+	if err != nil {
+		t.Fatalf("failed to extract YAML from PNG: %v", err)
+	}
+
+	if !bytes.Equal(extractedYAML, testYAML) {
+		t.Errorf("extracted YAML does not match original. Got %q, want %q", string(extractedYAML), string(testYAML))
+	}
+}
+
+func TestExtractMissingYAML(t *testing.T) {
+	pngBytes, err := generateMinimalPNG()
+	if err != nil {
+		t.Fatalf("failed to generate test PNG: %v", err)
+	}
+
+	_, err = ExtractYAMLFromPNG(pngBytes)
+	if err == nil {
+		t.Error("expected error extracting missing metadata, got nil")
+	}
+}
+
+func TestEmbedInvalidPNG(t *testing.T) {
+	invalidPNG := []byte("not a PNG image")
+	testYAML := []byte("Diagram:")
+
+	_, err := EmbedYAMLInPNG(invalidPNG, testYAML)
+	if err == nil {
+		t.Error("expected error embedding in invalid PNG, got nil")
+	}
+
+	_, err = ExtractYAMLFromPNG(invalidPNG)
+	if err == nil {
+		t.Error("expected error extracting from invalid PNG, got nil")
+	}
+}


### PR DESCRIPTION
### Summary
This PR adds support for embedding the diagram-as-code YAML configuration inside the generated PNG image as metadata, and adds an `extract` subcommand to the CLI to retrieve it. This resolves #258.

### Rationale
Currently, when diagram images are uploaded to wikis, blogs, or other platforms, it is difficult to find the original YAML code used to generate them if it is not explicitly attached or tracked. Storing the configuration directly inside the image metadata (similar to how PlantUML works) allows seamless retrieval of the source design.

### Changes
1. **PNG Metadata Chunk Injection**: Implemented manual parsing of PNG bytes to inject a standard `tEXt` chunk right after the `IHDR` chunk. The chunk uses the keyword `awsdac` and stores a base64-encoded representation of the source YAML.
2. **Metadata Extraction CLI Subcommand**: Added an `extract` subcommand to `awsdac` to scan PNG chunks, locate the `awsdac` metadata chunk, base64-decode the content, and output the original YAML to stdout.
3. **YAML Preservation**: 
   - For DAC YAML files, the rendered/processed YAML is embedded.
   - For CloudFormation templates, the template is marshaled back into equivalent DAC YAML and embedded.
4. **Unit Tests**: Added comprehensive tests covering embedding, extraction, and validation of PNG metadata.

### Verification
All unit tests and integration tests compile and pass successfully:
```bash
go test ./...
```

Manual testing verified:
```bash
# Build the binary
go build -o awsdac cmd/awsdac/main.go

# Generate diagram with YAML metadata embedded
./awsdac examples/span-resources.yaml -o test_output.png -f

# Extract metadata
./awsdac extract test_output.png
```
The extraction successfully prints the exact YAML contents of the original diagram design file.
