### PR TITLE
docs: fix broken links and add missing examples in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,11 @@
 ![alb-ec2.png](alb-ec2.png)
 (generated from [alb-ec2.yaml](alb-ec2.yaml))
 
+## Load balancing an Auto Scaling group of web servers using ALB
+
+![alb-asg.png](alb-asg.png)
+(generated from [alb-asg.yaml](alb-asg.yaml))
+
 ## Multi-region redundancy
 
 ![multi-region.png](multi-region.png)
@@ -22,5 +27,20 @@
 
 ## Network firewall that inspects communication between VPCs
 
-![tgw-nwfw.png](tgw-nwfw.png)
-(generated from [tgw-nwfw.yaml](tgw-nwfw.yaml))
+![tgw-nwfw-tmpl.png](tgw-nwfw-tmpl.png)
+(generated from [tgw-nwfw-tmpl.yaml](tgw-nwfw-tmpl.yaml))
+
+## A load balancer spanning multiple subnets
+
+![span-resources.png](span-resources.png)
+(generated from [span-resources.yaml](span-resources.yaml))
+
+## Expanding a group to fill its parent with Align: expand
+
+![expand-align.png](expand-align.png)
+(generated from [expand-align.yaml](expand-align.yaml))
+
+## EC2 instances in a VPC, generated from a CloudFormation template
+
+![vpc-subnet-ec2-cfn.png](vpc-subnet-ec2-cfn.png)
+(generated from CloudFormation template [vpc-subnet-ec2-cfn.yaml](vpc-subnet-ec2-cfn.yaml))


### PR DESCRIPTION
### Summary

This PR fixes broken links and adds four missing examples in `examples/README.md`. Resolves #298. Documentation only, no code changes.

### Changes

1. **Fixed broken links.** The "Network firewall that inspects communication between VPCs" section linked to `tgw-nwfw.png` and `tgw-nwfw.yaml`, which do not exist (both 404). Updated to the files that do exist, `tgw-nwfw-tmpl.png` and `tgw-nwfw-tmpl.yaml`.
2. **Added four missing examples.** Four example pairs exist in `examples/` but were not listed in the README. Added a section for each in the existing format:
   - `alb-asg` (Auto Scaling group behind an ALB)
   - `span-resources` (a load balancer spanning multiple subnets)
   - `expand-align` (expanding a group to fill its parent with `Align: expand`)
   - `vpc-subnet-ec2-cfn` (EC2 in a VPC, generated from a CloudFormation template; its entry notes the input is a CloudFormation template rather than a DAC file)

### Verification

Every link in `examples/README.md` was checked to resolve to a file present in `examples/`. No code paths are touched.
